### PR TITLE
Location codes changes

### DIFF
--- a/R/colombia.R
+++ b/R/colombia.R
@@ -25,20 +25,5 @@ get_colombia_regional_cases <- function() {
                   region_level_1 = stringr::str_replace_all(region_level_1, "ARCHIPIELAGO DE SAN ANDRES PROVIDENCIA Y SANTA CATALINA", "San Andres, Providencia y Santa Catalina"),
                   region_level_1 = stringr::str_to_sentence(region_level_1))
 
-  # Get ISO codes -----------------------------------------------------------------
-  region_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:CO"
-  iso_table <- region_url %>%
-    xml2::read_html() %>%
-    rvest::html_nodes(xpath='//*[@id="mw-content-text"]/div/table') %>%
-    rvest::html_table()
-  iso <- iso_table[[1]] %>%
-    dplyr::select(iso_code = Code, region_level_1 = 2) %>%
-    dplyr::mutate(region_level_1 = iconv(x = region_level_1, from = "UTF-8", to = "ASCII//TRANSLIT"),
-                  region_level_1 = stringr::str_replace_all(region_level_1, "Distrito Capital de ", ""),
-                  region_level_1 = stringr::str_to_sentence(region_level_1))
-
-  # Merge ISO codes with data ------------------------------------------------------
-  colombia <- dplyr::left_join(colombia, iso, by = "region_level_1")
-
   return(colombia)
 }

--- a/R/covid19R_wrappers.R
+++ b/R/covid19R_wrappers.R
@@ -39,8 +39,19 @@ refresh_covidregionaldata_brazil <- function() {
 #' Data sourced from https://health-infobase.canada.ca/src/data/covidLive/covid19.csv.
 #' @return A tibble of COVID cases by province in Canada.
 #' @export
-refresh_covidregionaldata_canada<- function() {
+refresh_covidregionaldata_canada <- function() {
   data <- get_regional_data("canada", totals = FALSE, include_level_2_regions = FALSE)
+  data <- convert_to_covid19R_format(data)
+  return(tibble::tibble(data))
+}
+
+#' Get daily Colombian COVID-19 count data by Department (Departamento).
+#' @description Fetches  COVID-19 count data, stratified by date and region.
+#' Data sourced from https://raw.githubusercontent.com/ideascol/covid19/master/data/data_dptos_trend.csv.
+#' @return A tibble of COVID cases by province in Colombia.
+#' @export
+refresh_covidregionaldata_colombia <- function() {
+  data <- get_regional_data("colombia", totals = FALSE, include_level_2_regions = FALSE)
   data <- convert_to_covid19R_format(data)
   return(tibble::tibble(data))
 }
@@ -74,6 +85,40 @@ refresh_covidregionaldata_india <- function() {
 #' @export
 refresh_covidregionaldata_italy <- function() {
   data <- get_regional_data("italy", totals = FALSE, include_level_2_regions = FALSE)
+  data <- convert_to_covid19R_format(data)
+  return(tibble::tibble(data))
+}
+
+#' Get daily Russian COVID-19 count data by Russian region.
+#' @description Fetches  COVID-19 count data, stratified by date and region.
+#' Data sourced from https://raw.githubusercontent.com/grwlf/COVID-19_plus_Russia/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_RU.csv.
+#' @return A tibble of COVID cases by province in Russia.
+#' @export
+refresh_covidregionaldata_russia <- function() {
+  data <- get_regional_data("russia", totals = FALSE, include_level_2_regions = FALSE)
+  data <- convert_to_covid19R_format(data)
+  return(tibble::tibble(data))
+}
+
+#' Get daily UK COVID-19 count data by EU-defined region
+#' @description Fetches  COVID-19 count data, stratified by date and region.
+#' Data sourced from https://coronavirus.data.gov.uk/downloads/csv/coronavirus-cases_latest.csv and
+#' https://raw.githubusercontent.com/tomwhite/covid-19-uk-data/master/data/covid-19-cases-uk.csv.
+#' @return A tibble of COVID cases by EU region in UK.
+#' @export
+refresh_covidregionaldata_uk <- function() {
+  data <- get_regional_data("uk", totals = FALSE, include_level_2_regions = FALSE)
+  data <- convert_to_covid19R_format(data)
+  return(tibble::tibble(data))
+}
+
+#' Get daily USA COVID-19 count data by state.
+#' @description Fetches  COVID-19 count data, stratified by date and region.
+#' Data sourced from https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv.
+#' @return A tibble of COVID cases by state in USA
+#' @export
+refresh_covidregionaldata_usa <- function() {
+  data <- get_regional_data("usa", totals = FALSE, include_level_2_regions = FALSE)
   data <- convert_to_covid19R_format(data)
   return(tibble::tibble(data))
 }
@@ -134,6 +179,17 @@ get_info_covidregionaldata <- function() {
     "state",
     "country",
     FALSE,
+    
+    "covidregionaldata_colombia",
+    "covidregionaldata",
+    "refresh_covidregionaldata_colombia",
+    "Daily Covid-19 count data for Departments of Colombia",
+    "https://raw.githubusercontent.com/ideascol/covid19/master/data/data_dptos_trend.csv",
+    "https://github.com/epiforecasts/covidregionaldata/blob/master/LICENSE",
+    "cases_new, cases_total, deaths_new, deaths_total, recovered_new, recovered_total, hosp_new, tested_total",
+    "state",
+    "country",
+    FALSE,
 
     "covidregionaldata_germany",
     "covidregionaldata",
@@ -162,6 +218,40 @@ get_info_covidregionaldata <- function() {
     "refresh_covidregionaldata_italy",
     "Daily Covid-19 count data for regions (Regioni) of Italy",
     "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni-<date>.csv",
+    "https://github.com/epiforecasts/covidregionaldata/blob/master/LICENSE",
+    "cases_new, cases_total, deaths_new, deaths_total, recovered_new, recovered_total, hosp_new, tested_total",
+    "state",
+    "country",
+    FALSE,
+    
+    "covidregionaldata_russia",
+    "covidregionaldata",
+    "refresh_covidregionaldata_russia",
+    "Daily Covid-19 count data for Regions of Russia",
+    "https://raw.githubusercontent.com/grwlf/COVID-19_plus_Russia/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_RU.csv",
+    "https://github.com/epiforecasts/covidregionaldata/blob/master/LICENSE",
+    "cases_new, cases_total, deaths_new, deaths_total, recovered_new, recovered_total, hosp_new, tested_total",
+    "state",
+    "country",
+    FALSE,
+    
+    "covidregionaldata_uk",
+    "covidregionaldata",
+    "refresh_covidregionaldata_uk",
+    "Daily Covid-19 count data for EU-defined regions of the UK",
+    "https://coronavirus.data.gov.uk/downloads/csv/coronavirus-cases_latest.csv, 
+    https://raw.githubusercontent.com/tomwhite/covid-19-uk-data/master/data/covid-19-cases-uk.csv",
+    "https://github.com/epiforecasts/covidregionaldata/blob/master/LICENSE",
+    "cases_new, cases_total, deaths_new, deaths_total, recovered_new, recovered_total, hosp_new, tested_total",
+    "state",
+    "country",
+    FALSE,
+    
+    "covidregionaldata_usa",
+    "covidregionaldata",
+    "refresh_covidregionaldata_usa",
+    "Daily Covid-19 count data for states of the US",
+    "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv",
     "https://github.com/epiforecasts/covidregionaldata/blob/master/LICENSE",
     "cases_new, cases_total, deaths_new, deaths_total, recovered_new, recovered_total, hosp_new, tested_total",
     "state",

--- a/R/get_iso_codes.R
+++ b/R/get_iso_codes.R
@@ -216,7 +216,17 @@ get_uk_iso_codes <- function() {
 #' Colombia ISO codes (NULL - they're in the raw data already)
 #' 
 get_colombia_iso_codes <- function() {
-  return(NULL)
+  region_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:CO"
+  iso_table <- region_url %>%
+    xml2::read_html() %>%
+    rvest::html_nodes(xpath='//*[@id="mw-content-text"]/div/table') %>%
+    rvest::html_table()
+  iso <- iso_table[[1]] %>%
+    dplyr::select(iso_code = Code, region_level_1 = 2) %>%
+    dplyr::mutate(region_level_1 = iconv(x = region_level_1, from = "UTF-8", to = "ASCII//TRANSLIT"),
+                  region_level_1 = stringr::str_replace_all(region_level_1, "Distrito Capital de ", ""),
+                  region_level_1 = stringr::str_to_sentence(region_level_1))
+  return(iso)
 }
 
 # Level 2 regions -------------------------------------------------------------------------------------

--- a/R/get_region_codes.R
+++ b/R/get_region_codes.R
@@ -150,7 +150,7 @@ get_italy_region_codes <- function() {
 #' @importFrom tibble tibble
 #' 
 get_russia_region_codes <- function() {
-  region_url <- "https://en.wikipedia.org/wiki/region_3166-2:RU"
+  region_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:RU"
   region_table <- region_url %>%
     xml2::read_html() %>%
     rvest::html_nodes(xpath='//*[@id="mw-content-text"]/div/table') %>%

--- a/R/get_region_codes.R
+++ b/R/get_region_codes.R
@@ -1,30 +1,30 @@
 # Mains -------------------------------------------------------------------------------------
 
-#' Get a table of ISO codes for a specified country
+#' Get a table of region codes for a specified country
 #' @param country a string with a country specified
-#' @return a tibble of regions and their corresponding ISO codes
+#' @return a tibble of regions and their corresponding region codes
 #' @importFrom tibble tibble
-get_iso_codes <- function(country) {
+get_region_codes <- function(country) {
 
-  iso_code_fun <- switch(country,
-                         "afghanistan" = get_afghan_iso_codes,
-                         "belgium" = get_belgium_iso_codes,
-                         "brazil" = get_brazil_iso_codes,
-                         "canada" = get_canada_iso_codes,
-                         "colombia" = get_colombia_iso_codes,
-                         "germany" = get_germany_iso_codes,
-                         "india" = get_india_iso_codes,
-                         "italy" = get_italy_iso_codes,
-                         "russia" = get_russia_iso_codes,
-                         "uk" = get_uk_iso_codes,
-                         "usa" = get_us_iso_codes)
+  region_code_fun <- switch(country,
+                         "afghanistan" = get_afghan_region_codes,
+                         "belgium" = get_belgium_region_codes,
+                         "brazil" = get_brazil_region_codes,
+                         "canada" = get_canada_region_codes,
+                         "colombia" = get_colombia_region_codes,
+                         "germany" = get_germany_region_codes,
+                         "india" = get_india_region_codes,
+                         "italy" = get_italy_region_codes,
+                         "russia" = get_russia_region_codes,
+                         "uk" = get_uk_region_codes,
+                         "usa" = get_us_region_codes)
 
-  iso_codes_table <- do.call(iso_code_fun, list())
+  region_codes_table <- do.call(region_code_fun, list())
 
-  return(iso_codes_table)
+  return(region_codes_table)
 }
 
-#' Get a table of level 2 region codes (FIPS, ONS, ISO) for a specified country
+#' Get a table of level 2 region codes (FIPS, ONS, region) for a specified country
 #' @param country a string with a country specified
 #' @return a tibble of regions and their corresponding level 2 region codes
 #' @importFrom tibble tibble
@@ -44,12 +44,12 @@ get_level_2_region_codes <- function(country) {
 
 # Level 1 regions -------------------------------------------------------------------------------------
 
-#' Afghan ISO codes
+#' Afghan region codes
 #' @importFrom tibble tibble
 #' 
-get_afghan_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("AF-BAL", "AF-BAM", "AF-BDG", "AF-BDS", "AF-BGL", "AF-DAY", "AF-FRA", "AF-FYB",
+get_afghan_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("AF-BAL", "AF-BAM", "AF-BDG", "AF-BDS", "AF-BGL", "AF-DAY", "AF-FRA", "AF-FYB",
              "AF-GHA", "AF-GHO", "AF-HEL", "AF-HER", "AF-JOW", "AF-KAB", "AF-KAN", "AF-KAP",
              "AF-KDZ", "AF-KHO", "AF-KNR", "AF-LAG", "AF-LOG", "AF-NAN", "AF-NIM", "AF-NUR",
              "AF-PAN", "AF-PAR", "AF-PIA", "AF-PKA", "AF-SAM", "AF-SAR", "AF-TAK", "AF-URU",
@@ -57,25 +57,25 @@ get_afghan_iso_codes <- function() {
     region = c("Balkh", "Badghis", "Baghlan", "Badakhshan", "Bamyan", "Daykundi", "Farah", "Faryab", "Ghazni", "Ghor", "Helmand", "Herat",
                "Jowzjan", "Kabul", "Kandahar", "Kapisa", "Kunduz", "Khost", "Kunar", "Laghman", "Logar", "Nangarhar", "Nimruz", "Nuristan",
                "Panjshir", "Parwan", "Paktia", "Paktika", "Samangan", "Sar-e Pol", "Takhar", "Urozgan", "Wardak", "Zabul"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Belgian ISO codes
+#' Belgian region codes
 #' @importFrom tibble tibble
 #' 
-get_belgium_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("BE-BRU", "BE-VLG", "BE-WAL"),
+get_belgium_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("BE-BRU", "BE-VLG", "BE-WAL"),
     region = c("Brussels", "Flanders", "Wallonia"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Brazilian ISO codes
+#' Brazilian region codes
 #' @importFrom tibble tibble
 #' 
-get_brazil_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("BR-AC", "BR-AL", "BR-AM", "BR-AP", "BR-BA", "BR-CE", "BR-DF", "BR-ES", "BR-FN",
+get_brazil_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("BR-AC", "BR-AL", "BR-AM", "BR-AP", "BR-BA", "BR-CE", "BR-DF", "BR-ES", "BR-FN",
              "BR-GO", "BR-MA", "BR-MG", "BR-MS", "BR-MT", "BR-PA", "BR-PB", "BR-PE", "BR-PI",
              "BR-PR", "BR-RJ", "BR-RN", "BR-RO", "BR-RR", "BR-RS", "BR-SC", "BR-SE", "BR-SP",
              "BR-TO"),
@@ -83,40 +83,40 @@ get_brazil_iso_codes <- function() {
                "Espirito Santo", "Fernando de Noronha", "Goiás", "Maranhão", "Minas Gerais", "Mato Grosso do Sul", "Mato Grosso",
                "Pará", "Paraíba", "Pernambuco", "Piauí", "Paraná", "Rio de Janeiro", "Rio Grande do Norte",
                "Rondônia", "Roraima", "Rio Grande do Sul", "Santa Catarina", "Sergipe", "São Paulo", "Tocantins"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Canadian ISO codes
+#' Canadian region codes
 #' @importFrom tibble tibble
 #' 
-get_canada_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("CA-AB", "CA-BC", "CA-MB", "CA-NB", "CA-NL", "CA-NS", "CA-NT", "CA-NU", "CA-ON", "CA-PE", "CA-QC", "CA-SK", "CA-YT"),
+get_canada_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("CA-AB", "CA-BC", "CA-MB", "CA-NB", "CA-NL", "CA-NS", "CA-NT", "CA-NU", "CA-ON", "CA-PE", "CA-QC", "CA-SK", "CA-YT"),
     region = c("Alberta", "British Columbia", "Manitoba", "New Brunswick", "Newfoundland and Labrador",
                "Nova Scotia", "Northwest Territories", "Nunavut", "Ontario", "Prince Edward Island",
                "Quebec", "Saskatchewan", "Yukon"))
-    return(iso_codes)
+    return(region_codes)
 }
 
-#' German ISO codes
+#' German region codes
 #' @importFrom tibble tibble
 #' 
-get_germany_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("DE-BB", "DE-BE", "DE-BW", "DE-BY", "DE-HB", "DE-HE", "DE-HH", "DE-MV",
+get_germany_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("DE-BB", "DE-BE", "DE-BW", "DE-BY", "DE-HB", "DE-HE", "DE-HH", "DE-MV",
              "DE-NI", "DE-NW", "DE-RP", "DE-SH", "DE-SL", "DE-SN", "DE-ST", "DE-TH"),
     region = c("Brandenburg", "Berlin", "Baden-Württemberg", "Bayern", "Bremen", "Hessen",
                "Hamburg", "Mecklenburg-Vorpommern", "Niedersachsen", "Nordrhein-Westfalen",
                "Rheinland-Pfalz", "Schleswig-Holstein", "Saarland", "Sachsen", "Sachsen-Anhalt", "Thüringen"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Indian ISO codes
+#' Indian region codes
 #' @importFrom tibble tibble
 #' 
-get_india_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("IN-AN", "IN-AP", "IN-AR", "IN-AS", "IN-BR", "IN-CH", "IN-CT", "IN-DD", "IN-DL",
+get_india_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("IN-AN", "IN-AP", "IN-AR", "IN-AS", "IN-BR", "IN-CH", "IN-CT", "IN-DD", "IN-DL",
              "IN-DN", "IN-GA", "IN-GJ", "IN-HP", "IN-HR", "IN-JH", "IN-JK", "IN-KA", "IN-KL",
              "IN-LA", "IN-LD", "IN-MH", "IN-ML", "IN-MN", "IN-MP", "IN-MZ", "IN-NL", "IN-OR",
              "IN-PB", "IN-PY", "IN-RJ", "IN-SK", "IN-TG", "IN-TN", "IN-TR", "IN-UP", "IN-UT", "IN-WB"),
@@ -128,37 +128,37 @@ get_india_iso_codes <- function() {
                "Odisha", "Punjab", "Puducherry", "Rajasthan", "Sikkim",
                "Telangana", "Tamil Nadu", "Tripura", "Uttar Pradesh", "Uttarakhand",
                "West Bengal"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Italian ISO codes
+#' Italian region codes
 #' @importFrom tibble tibble
 #' 
-get_italy_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("IT-21", "IT-23", "IT-25", "IT-32", "IT-34", "IT-36", "IT-42", "IT-45", "IT-52",
+get_italy_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("IT-21", "IT-23", "IT-25", "IT-32", "IT-34", "IT-36", "IT-42", "IT-45", "IT-52",
              "IT-55", "IT-57", "IT-62", "IT-65", "IT-67", "IT-72", "IT-75", "IT-77", "IT-78",
              "IT-82", "IT-88"),
     region = c("Piemonte", "Valle d'Aosta", "Lombardia", "Trentino-Alto Adige", "Veneto", "Friuli Venezia Giulia",
                "Liguria", "Emilia-Romagna", "Toscana", "Umbria", "Marche", "Lazio",
                "Abruzzo", "Molise", "Campania", "Puglia", "Basilicata", "Calabria",
                "Sicilia", "Sardegna"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' Russian ISO codes
+#' Russian region codes
 #' @importFrom tibble tibble
 #' 
-get_russia_iso_codes <- function() {
-  region_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:RU"
-  iso_table <- region_url %>%
+get_russia_region_codes <- function() {
+  region_url <- "https://en.wikipedia.org/wiki/region_3166-2:RU"
+  region_table <- region_url %>%
     xml2::read_html() %>%
     rvest::html_nodes(xpath='//*[@id="mw-content-text"]/div/table') %>%
     rvest::html_table(fill=TRUE)
-  iso_code <- iso_table[[1]][-1,]$Code
+  region_code <- region_table[[1]][-1,]$Code
   
-  iso_codes <- tibble::tibble(
-    iso_code = c(iso_code, "UA-40", "UA-43"), 
+  region_codes <- tibble::tibble(
+    level_1_region_code = c(region_code, "UA-40", "UA-43"), 
     region = c("Adygea Republic", "Altai Republic", "Bashkortostan Republic", "Buryatia Republic",
     "Chechen Republic", "Chuvashia Republic", "Dagestan Republic", "Ingushetia Republic", 
     "Kabardino-Balkarian Republic", "Kalmykia Republic", "Karachay-Cherkess Republic", "Karelia Republic",
@@ -181,15 +181,15 @@ get_russia_iso_codes <- function() {
     "Khanty-Mansi Autonomous Okrug", "Nenets Autonomous Okrug", "Yamalo-Nenets Autonomous Okrug", "Sevastopol",
     "Republic of Crimea"))
   
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' US ISO codes
+#' US region codes
 #' @importFrom tibble tibble
 #' 
-get_us_iso_codes <- function() {
-  iso_codes <- tibble::tibble(
-    iso_code = c("US-AL", "US-AK", "US-AZ", "US-AR", "US-CA", "US-CO", "US-CT", "US-DE", "US-FL", "US-GA",
+get_us_region_codes <- function() {
+  region_codes <- tibble::tibble(
+    level_1_region_code = c("US-AL", "US-AK", "US-AZ", "US-AR", "US-CA", "US-CO", "US-CT", "US-DE", "US-FL", "US-GA",
                  "US-HI", "US-ID", "US-IL", "US-IN", "US-IA", "US-KS", "US-KY", "US-LA", "US-ME", "US-MD",
                  "US-MA", "US-MI", "US-MN", "US-MS", "US-MO", "US-MT", "US-NE", "US-NV", "US-NH", "US-NJ",
                  "US-NM", "US-NY", "US-NC", "US-ND", "US-OH", "US-OK", "US-OR", "US-PA", "US-RI", "US-SC",
@@ -204,34 +204,34 @@ get_us_iso_codes <- function() {
                "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming", "District of Columbia",
                "American Samoa", "Guam", "Northern Mariana Islands", "Puerto Rico", "Minor Outlying Islands",
                "Virgin Islands"))
-  return(iso_codes)
+  return(region_codes)
 }
 
-#' UK ISO codes (NULL - they're in the raw data already)
+#' UK region codes (NULL - they're in the raw data already)
 #' 
-get_uk_iso_codes <- function() {
+get_uk_region_codes <- function() {
   return(NULL)
 }
 
-#' Colombia ISO codes (NULL - they're in the raw data already)
+#' Colombia region codes
 #' 
-get_colombia_iso_codes <- function() {
+get_colombia_region_codes <- function() {
   region_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:CO"
-  iso_table <- region_url %>%
+  region_table <- region_url %>%
     xml2::read_html() %>%
     rvest::html_nodes(xpath='//*[@id="mw-content-text"]/div/table') %>%
     rvest::html_table()
-  iso <- iso_table[[1]] %>%
-    dplyr::select(iso_code = Code, region_level_1 = 2) %>%
+  region <- region_table[[1]] %>%
+    dplyr::select(level_1_region_code = Code, region_level_1 = 2) %>%
     dplyr::mutate(region_level_1 = iconv(x = region_level_1, from = "UTF-8", to = "ASCII//TRANSLIT"),
                   region_level_1 = stringr::str_replace_all(region_level_1, "Distrito Capital de ", ""),
                   region_level_1 = stringr::str_to_sentence(region_level_1))
-  return(iso)
+  return(region)
 }
 
 # Level 2 regions -------------------------------------------------------------------------------------
 
-#' Beligan Provincial ISO codes
+#' Beligan Provincial region codes
 #' @importFrom tibble tibble
 #' 
 get_belgium_level_2_codes <- function() {

--- a/R/utils.R
+++ b/R/utils.R
@@ -241,17 +241,20 @@ calculate_columns_from_existing_data <- function(data) {
 #' 
 convert_to_covid19R_format <- function(data) {
   location_type <- colnames(data)[2]
+  location_code_type <- colnames(data)[3]
 
   data <- data %>%
     dplyr::select(-hosp_total, -tested_new) %>%
-    tidyr::pivot_longer(-c(date, !!location_type, level_1_region_code),  names_to = "data_type", values_to = "value")
-
-  data$location_code_type <- "iso-3166-2"
-  data$location_type <- "state"
+    tidyr::pivot_longer(-c(date, !!location_type, !!location_code_type),  names_to = "data_type", values_to = "value")
 
   data <- data %>%
-    dplyr::rename("location_code" = "level_1_region_code",
-                  "location" = !!location_type) %>%
+    dplyr::rename("location_code" = !!location_code_type,
+                  "location" = !!location_type) 
+  
+  data$location_code_type <- location_code_type
+  data$location_type <- location_type
+  
+  data <- data %>%
     dplyr::select(date,	location,	location_type, location_code, location_code_type,	data_type, value) %>%
     dplyr::arrange(date)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,6 +88,47 @@ rename_region_column <- function(data, country) {
   return(tibble::tibble(data))
 }
 
+#' Helper to rename the region code column in each dataset to the correct code type for each country (e.g. ISO-3166-2).
+#' @description The package relies on column name 'region_level_1_code' etc. during processing but this often isn't the most 
+#' sensible name for the column (e.g. iso-3166-2 makes more sense for US states). This simply renames the column as the final step in 
+#' processing before returning data to the user.
+#' @param data a data frame with a region_level_1_code column and optionally a region_level_2_code column
+#' @param country a string with the country of interest
+#' @return a tibble with the column(s) renamed to a sensible name
+#' @importFrom dplyr %>% rename
+#' @importFrom tibble tibble
+#' 
+rename_region_code_column <- function(data, country) {
+  
+  level_1_region_code_name <- switch(tolower(country),
+                                  "afghanistan" = "iso_3166_2",
+                                  "belgium" = "iso_3166_2",
+                                  "brazil" = "iso_3166_2",
+                                  "canada" = "iso_3166_2",
+                                  "colombia" = "iso_3166_2",
+                                  "germany" = "iso_3166_2",
+                                  "india" = "iso_3166_2",
+                                  "italy" = "iso_3166_2",
+                                  "russia" = "iso_3166_2",
+                                  "uk" = "ons_code",
+                                  "usa" = "iso_3166_2")
+  
+  data <- data %>% dplyr::rename(!!level_1_region_code_name := level_1_region_code)
+  
+  if ("level_2_region_code" %in% colnames(data)) {
+    level_2_region_code_name <- switch(tolower(country),
+                                  "belgium" = "iso_3166_2_province",
+                                  "brazil" = "level_2_region_code",
+                                  "germany" = "level_2_region_code",
+                                  "uk" = "ons_code",
+                                  "usa" = "fips")
+    
+    data <- data %>% dplyr::rename(!!level_2_region_code_name := level_2_region_code)
+  }
+  
+  return(tibble::tibble(data))
+}
+
 #' Set negative data to 0
 #' @description Set data values to 0 if they are negative in a dataset. Data in the datasets should always be > 0.
 #' @param data a data table
@@ -123,10 +164,10 @@ fill_empty_dates_with_na <- function(data) {
   if ("region_level_2" %in% colnames(data)) {
     data <- data %>%
       tidyr::complete(date = tidyr::full_seq(data$date, period = 1), tidyr::nesting(region_level_2, level_2_region_code,
-                                                                                    region_level_1, iso_code))
+                                                                                    region_level_1, level_1_region_code))
   } else {
     data <- data %>%
-      tidyr::complete(date = tidyr::full_seq(data$date, period = 1), tidyr::nesting(region_level_1, iso_code))
+      tidyr::complete(date = tidyr::full_seq(data$date, period = 1), tidyr::nesting(region_level_1, level_1_region_code))
   }
 
   return(tibble::tibble(data))
@@ -147,13 +188,13 @@ complete_cumulative_columns <- function(data) {
     if (cumulative_col_name %in% colnames(data)){
       if ("region_level_2" %in% colnames(data)) {
         data <- data %>%
-          dplyr::group_by(region_level_1, iso_code, region_level_2, level_2_region_code) %>%
-          tidyr::fill(cumulative_col_name) %>%
+          dplyr::group_by(region_level_1, level_1_region_code, region_level_2, level_2_region_code) %>%
+          tidyr::fill(all_of(cumulative_col_name)) %>%
           dplyr::ungroup()
       } else {
         data <- data %>%
-          dplyr::group_by(region_level_1, iso_code,) %>%
-          tidyr::fill(cumulative_col_name) %>%
+          dplyr::group_by(region_level_1, level_1_region_code,) %>%
+          tidyr::fill(all_of(cumulative_col_name)) %>%
           dplyr::ungroup()
       }
     }
@@ -203,13 +244,13 @@ convert_to_covid19R_format <- function(data) {
 
   data <- data %>%
     dplyr::select(-hosp_total, -tested_new) %>%
-    tidyr::pivot_longer(-c(date, !!location_type, iso_code),  names_to = "data_type", values_to = "value")
+    tidyr::pivot_longer(-c(date, !!location_type, level_1_region_code),  names_to = "data_type", values_to = "value")
 
   data$location_code_type <- "iso-3166-2"
   data$location_type <- "state"
 
   data <- data %>%
-    dplyr::rename("location_code" = "iso_code",
+    dplyr::rename("location_code" = "level_1_region_code",
                   "location" = !!location_type) %>%
     dplyr::select(date,	location,	location_type, location_code, location_code_type,	data_type, value) %>%
     dplyr::arrange(date)
@@ -244,19 +285,19 @@ csv_reader <- function(file, ...) {
 #' Custom left_join function
 #' @description Checks if table that is being added is NULL and then uses left_join
 #' @param data a data table
-#' @param iso_codes_table a table of ISO codes which will be left_join (optionally NULL)
+#' @param region_codes_table a table of region codes which will be left_join (optionally NULL)
 #' @param by see dplyr::left_join() description of by parameter
 #' @param ... optional arguments passed into dplyr::left_join()
 #' @return A data table
 #' @importFrom dplyr left_join
 #' @importFrom tibble tibble
 #' 
-left_join_region_codes <- function(data, iso_codes_table, by = NULL, ...) {
-  if (is.null(iso_codes_table)) {
+left_join_region_codes <- function(data, region_codes_table, by = NULL, ...) {
+  if (is.null(region_codes_table)) {
     return(data)
   }
   
-  data <- dplyr::left_join(data, iso_codes_table, by = by, ...)
+  data <- dplyr::left_join(data, region_codes_table, by = by, ...)
   return(tibble::tibble(data))
 }
 
@@ -273,10 +314,10 @@ totalise_data <- function(data, include_level_2_regions) {
   # Group the data ------------------------------------------------------
   if (include_level_2_regions) {
     data <- data %>%
-      dplyr::group_by(region_level_1, iso_code, region_level_2, level_2_region_code)
+      dplyr::group_by(region_level_1, level_1_region_code, region_level_2, level_2_region_code)
   } else {
     data <- data %>%
-      dplyr::group_by(region_level_1, iso_code)
+      dplyr::group_by(region_level_1, level_1_region_code)
   }
   
   # Total the data ------------------------------------------------------
@@ -292,11 +333,11 @@ totalise_data <- function(data, include_level_2_regions) {
   if (include_level_2_regions) {
     data <- data %>%
       dplyr::select(region_level_2, level_2_region_code,
-                    region_level_1, iso_code, cases_total, deaths_total,
+                    region_level_1, level_1_region_code, cases_total, deaths_total,
                     recovered_total, hosp_total, tested_total)
   } else {
     data <- data %>%
-      dplyr::select(region_level_1, iso_code, cases_total, deaths_total,
+      dplyr::select(region_level_1, level_1_region_code, cases_total, deaths_total,
                     recovered_total, hosp_total, tested_total)
   }
   

--- a/tests/testthat/custom_tests/mock_data.R
+++ b/tests/testthat/custom_tests/mock_data.R
@@ -14,8 +14,8 @@ get_expected_data_for_get_regional_data_tests_only_level_1_regions <- function()
   ## Dates/provinces
   dates <- c("2020-01-31", "2020-02-01", "2020-02-02", "2020-02-03", "2020-02-04", "2020-02-05")
   provinces <- c("Northland", "Eastland", "Southland", "Westland", "Virginia")
-  ## Fake ISO codes
-  iso_codes <- tibble::tibble(iso_code = c("NO", "EA", "SO", "WE", "VA"), region = provinces)
+  ## Fake region codes
+  region_codes <- tibble::tibble(iso_3166_2 = c("NO", "EA", "SO", "WE", "VA"), region = provinces)
 
   expected_data_for_provinces <- list()
   for (i in 1:length(provinces)) {
@@ -70,8 +70,8 @@ get_expected_data_for_get_regional_data_tests_only_level_1_regions <- function()
                   recovered_total = as.numeric(recovered_total),
                   hosp_new = as.numeric(hosp_new),
                   hosp_total = as.numeric(hosp_total)) %>%
-    dplyr::left_join(iso_codes, by = c("province" = "region")) %>%
-    dplyr::select(date, province, iso_code, cases_new, cases_total, deaths_new,
+    dplyr::left_join(region_codes, by = c("province" = "region")) %>%
+    dplyr::select(date, province, iso_3166_2, cases_new, cases_total, deaths_new,
                   deaths_total, recovered_new, recovered_total,
                   hosp_new, hosp_total, tested_new,
                   tested_total) %>%
@@ -96,7 +96,7 @@ get_expected_totals_data_for_get_regional_data_tests_only_level_1_regions <- fun
   ## Totals data to test function when totals = TRUE
   totals_data <- expected_data[c(26:30), c(2, 3, 5, 7, 9, 11, 13)]
   totals_data[, 7] <- rep(0, 5)
-  colnames(totals_data) <- c("province", "iso_code", "cases_total", "deaths_total", "recovered_total", "hosp_total", "tested_total")
+  colnames(totals_data) <- c("province", "iso_3166_2", "cases_total", "deaths_total", "recovered_total", "hosp_total", "tested_total")
   totals_data <- totals_data %>% dplyr::arrange(-cases_total)
 
   return(tibble::tibble(totals_data))
@@ -123,16 +123,16 @@ get_expected_data_for_get_regional_data_tests_with_level_2_regions <- function()
   data <- get_expected_data_for_get_regional_data_tests_only_level_1_regions()
   data <- data[, -3]
   data$region <- rep(c("Oneland", "Oneland", "Twoland", "USA", "Twoland"), 6)
-  iso_codes <- tibble::tibble(iso_code = c("ON", "TW", "US"),
+  region_codes <- tibble::tibble(iso_3166_2 = c("ON", "TW", "US"),
                               region = c("Oneland", "Twoland", "USA"))
-  level_2_region_codes <- tibble::tibble(level_2_region_code = c("NO", "EA", "SO", "WE", "VA"),
+  level_2_region_codes <- tibble::tibble(iso_3166_2_province = c("NO", "EA", "SO", "WE", "VA"),
                                       region = c("Northland", "Eastland", "Southland", 
                                                  "Westland", "Virginia"))
 
   data <- data %>%
-    dplyr::left_join(iso_codes, by = "region") %>%
+    dplyr::left_join(region_codes, by = "region") %>%
     dplyr::left_join(level_2_region_codes, by = c("province" = "region")) %>%
-    dplyr::select(date, province, level_2_region_code, region, iso_code, 
+    dplyr::select(date, province, iso_3166_2_province, region, iso_3166_2, 
                   cases_new, cases_total, deaths_new, deaths_total, 
                   recovered_new, recovered_total, hosp_new, hosp_total, 
                   tested_new, tested_total) %>%
@@ -146,16 +146,16 @@ get_expected_totals_data_for_get_regional_data_tests_with_level_2_regions <- fun
 
   data <- data[, -2]
   data$region <- c("Oneland", "USA", "Twoland", "Twoland", "Oneland")
-  iso_codes <- tibble::tibble(iso_code = c("ON", "TW", "US"),
+  region_codes <- tibble::tibble(iso_3166_2 = c("ON", "TW", "US"),
                               region = c("Oneland", "Twoland", "USA"))
-  level_2_region_codes <- tibble::tibble(level_2_region_code = c("NO", "EA", "SO", "WE", "VA"),
+  level_2_region_codes <- tibble::tibble(iso_3166_2_province = c("NO", "EA", "SO", "WE", "VA"),
                                       region = c("Northland", "Eastland", "Southland", 
                                                  "Westland", "Virginia"))
   
   data <- data %>%
-    dplyr::left_join(iso_codes, by = "region") %>%
+    dplyr::left_join(region_codes, by = "region") %>%
     dplyr::left_join(level_2_region_codes, by = c("province" = "region")) %>%
-    dplyr::select(province, level_2_region_code, region, iso_code, cases_total, deaths_total,
+    dplyr::select(province, iso_3166_2_province, region, iso_3166_2, cases_total, deaths_total,
                   recovered_total, hosp_total, tested_total)
 
   return(tibble::tibble(data))
@@ -169,8 +169,8 @@ get_expected_data_for_fill_empty_dates_with_na_test <- function() {
   dates <- c("2020-01-31", "2020-02-01", "2020-02-02", "2020-02-03")
   regions <- c("Northland", "Eastland", "Wisconsin")
   
-  iso_codes <- tibble::tibble(region = regions,
-                              iso_code = c("NO", "EA", "WI"))
+  region_codes <- tibble::tibble(region = regions,
+                                 level_1_region_code = c("NO", "EA", "WI"))
 
   # full data is data with all dates/regions + some NAs in the cases column
   expected_data <- data.frame(expand.grid(dates, regions))
@@ -179,7 +179,7 @@ get_expected_data_for_fill_empty_dates_with_na_test <- function() {
   expected_data$region_level_1 <- as.character(expected_data$region_level_1)
   expected_data <- expected_data %>%
     dplyr::arrange(date, region_level_1) %>%
-    dplyr::left_join(iso_codes, by = c("region_level_1" = "region"))
+    dplyr::left_join(region_codes, by = c("region_level_1" = "region"))
   expected_data$cases <- c(1:5, rep(NA, 4), 10:12)
   return(tibble::tibble(expected_data))
 }
@@ -214,12 +214,12 @@ get_input_data_for_covid19R_converter_test <- function() {
   dates <- c("2020-01-31", "2020-02-01", "2020-02-02", "2020-02-03")
   regions <- c("Northland", "Eastland", "Wisconsin")
 
-  iso_code <- c("NO", "EA", "WI")
-  iso_table <- data.frame(cbind(regions, iso_code))
+  level_1_region_code <- c("NO", "EA", "WI")
+  region_table <- data.frame(cbind(regions, level_1_region_code))
 
   dates_and_regions <- data.frame(expand.grid(dates, regions, stringsAsFactors = FALSE))
   colnames(dates_and_regions) <- c("date", "region")
-  dates_regions_iso <- dplyr::left_join(dates_and_regions, iso_table, by = c("region" = "regions")) %>% arrange(date)
+  dates_regions_iso <- dplyr::left_join(dates_and_regions, region_table, by = c("region" = "regions")) %>% arrange(date)
 
   set.seed(181)
   value <- floor(runif(120, 0, 100))

--- a/tests/testthat/test-get_colombia_regional_cases.R
+++ b/tests/testthat/test-get_colombia_regional_cases.R
@@ -7,7 +7,7 @@ test_that("get_colombia_regional_cases data source is unchanged and up to date",
 
 test_that("get_colombia_regional_cases returns the correct column names", {
   expected_colnames <- c("region_level_1", "date", "cases_total", "deaths_total",
-                         "tested_total", "iso_code")
+                         "tested_total")
   
   returned_colnames <- colnames(get_colombia_regional_cases())
   
@@ -23,5 +23,4 @@ test_that("get_colombia_regional_cases returns correct column types", {
   expect_is(data$cases_total, "numeric")
   expect_is(data$deaths_total, "numeric")
   expect_is(data$tested_total, "numeric")
-  expect_is(data$iso_code, "character")
 })

--- a/tests/testthat/test-get_regional_data.R
+++ b/tests/testthat/test-get_regional_data.R
@@ -22,12 +22,12 @@ test_that("get_regional_data returns error if totals arg is not logical", {
 ## this file contains functions which create data specifically for these tests
 source("custom_tests/mock_data.R")
 
-test_that("get_wide_format_regional_covid_data returns correct wide format data - admin level 1 only", {
+test_that("get_regional_data returns correct time series data - admin level 1 regions only", {
   # Set up and run
   input_data <- get_input_data_for_get_regional_data_tests_only_level_1_regions()
-  iso_codes <- tibble::tibble(iso_code = c("NO", "EA", "SO", "WE", "VA"),
+  region_codes <- tibble::tibble(level_1_region_code = c("NO", "EA", "SO", "WE", "VA"),
                               region = c("Northland", "Eastland", "Southland", "Westland", "Virginia"))
-  returned_data <- with_mock(get_canada_iso_codes = function(country) return(iso_codes),
+  returned_data <- with_mock(get_canada_region_codes = function(country) return(region_codes),
                              get_canada_regional_cases = function() return(input_data),
                              get_regional_data("canada", include_level_2_regions = FALSE))
 
@@ -37,15 +37,15 @@ test_that("get_wide_format_regional_covid_data returns correct wide format data 
   expect_equal(expected_data, returned_data)
 })
 
-test_that("get_wide_format_regional_covid_data returns correct wide format data - admin level 2", {
+test_that("get_regional_data returns correct time series - incl. admin level 2 regions", {
   # Set up and run
   input_data <- get_input_data_for_get_regional_data_tests_with_level_2_regions()
-  iso_codes <- tibble::tibble(iso_code = c("ON", "TW", "US"),
+  region_codes <- tibble::tibble(level_1_region_code = c("ON", "TW", "US"),
                               region = c("Oneland", "Twoland", "USA"))
   level_2_region_codes <- tibble::tibble(level_2_region_code = c("NO", "EA", "SO", "WE", "VA"),
                                       region = c("Northland", "Eastland", "Southland", "Westland", "Virginia"))
   
-  returned_data <- with_mock(get_iso_codes = function(country) return(iso_codes),
+  returned_data <- with_mock(get_region_codes = function(country) return(region_codes),
                              get_level_2_region_codes = function(country)  return(level_2_region_codes),
                              get_belgium_regional_cases_with_level_2 = function() return(input_data),
                              get_regional_data("belgium", include_level_2_regions = TRUE))
@@ -56,12 +56,12 @@ test_that("get_wide_format_regional_covid_data returns correct wide format data 
   expect_equal(expected_data, returned_data)
 })
 
-test_that("get_totals_only_regional_covid_data returns correct data - admin level 1", {
+test_that("get_regional_data returns correct totals data - admin level 1 regions only", {
   # Set up and run
   input_data <- get_input_data_for_get_regional_data_tests_only_level_1_regions()
-  iso_codes <- tibble::tibble(iso_code = c("NO", "EA", "SO", "WE", "VA"),
+  region_codes <- tibble::tibble(level_1_region_code = c("NO", "EA", "SO", "WE", "VA"),
                               region = c("Northland", "Eastland", "Southland", "Westland", "Virginia"))
-  returned_data <- with_mock(get_canada_iso_codes = function() return(iso_codes),
+  returned_data <- with_mock(get_canada_region_codes = function() return(region_codes),
                              get_canada_regional_cases = function() return(input_data),
                              get_regional_data("canada", totals = TRUE, include_level_2_regions = FALSE))
 
@@ -71,15 +71,15 @@ test_that("get_totals_only_regional_covid_data returns correct data - admin leve
   expect_equal(totals_data, returned_data)
 })
 
-test_that("get_totals_only_regional_covid_data returns correct data - admin level 2", {
+test_that("get_regional_data returns correct totals data - incl. admin level 2 regions", {
   # Set up and run
   input_data <- get_input_data_for_get_regional_data_tests_with_level_2_regions()
-  iso_codes <- tibble::tibble(iso_code = c("ON", "TW", "US"),
+  region_codes <- tibble::tibble(level_1_region_code = c("ON", "TW", "US"),
                               region = c("Oneland", "Twoland", "USA"))
   level_2_region_codes <- tibble::tibble(level_2_region_code = c("NO", "EA", "SO", "WE", "VA"),
                                       region = c("Northland", "Eastland", "Southland", "Westland", "Virginia"))
   
-  returned_data <- with_mock(get_iso_codes = function(country) return(iso_codes),
+  returned_data <- with_mock(get_region_codes = function(country) return(region_codes),
                              get_level_2_region_codes = function(country) return(level_2_region_codes),
                              get_belgium_regional_cases_with_level_2 = function() return(input_data),
                              get_regional_data("belgium", totals = TRUE, include_level_2_regions = TRUE))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -53,12 +53,25 @@ test_that("rename_region_column does so correctly", {
   expect_equal(colnames(rename_region_column(df, "belgium"))[1:2], c("region", "province"))
 })
 
+test_that("rename_region_code_column does so correctly", {
+  df <- data.frame(matrix(rnorm(100), ncol=10))
+  colnames(df)[1] <- "level_1_region_code"
+  
+  expect_error(rename_region_code_column(df, "test"))
+  expect_equal(colnames(rename_region_code_column(df, "canada"))[1], "iso_3166_2")
+  
+  colnames(df)[1] <- "level_1_region_code"
+  colnames(df)[2] <- "level_2_region_code"
+  expect_equal(colnames(rename_region_code_column(df, "usa"))[1:2], c("iso_3166_2", "fips"))
+})
+
 test_that("set_negative_values_to_zero works", {
-  df <- data.frame(matrix(c(rep(Sys.Date(), 100), 49:-50), ncol=2))
+  dates <- c(rep(Sys.Date(), 100))
+  values <- 49:-50
+  df <- tibble::tibble(date = dates, cases_total = values)
   colnames(df) <- c("date", "cases_total")
 
-  df_expected <- tibble::tibble(data.frame(matrix(c(rep(Sys.Date(), 100), c(49:0, rep(0, 50))), ncol=2)))
-  colnames(df_expected) <- c("date", "cases_total")
+  df_expected <- tibble::tibble(date = dates, cases_total = c(49:0, rep(0, 50)))
 
   df_actual <- set_negative_values_to_zero(df)
 


### PR DESCRIPTION
Changes to ISO codes so that:

> Internally, the variables are called "level_1_region_code" and "level_2_region_code"
> These are renamed as the final step before the data is returned to the user
> This means we can now use custom names for the region codes rather than just calling it iso_code

> also, I edited the Covid19R wrappers.