### PR TITLE
Specify tidyr version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Imports:
     magrittr,
     memoise,
     lubridate,
-    tidyr,
+    tidyr (>= 1.0.0),
     httr,
     yaml,
     readxl,


### PR DESCRIPTION
got caught out again with the old version of tidyr we have as our default... It fails with an unknown method that is only introduced in v1