### PR TITLE
Resolves issue with not all countries having a region 

### DIFF
--- a/R/get_national_data.R
+++ b/R/get_national_data.R
@@ -79,7 +79,6 @@ get_national_data <- function(country = NULL, totals = FALSE, source = "ecdc"){
     add_extra_na_cols() %>%
     set_negative_values_to_zero() %>%
     dplyr::ungroup()
-  
 
   # Totalise and return if totals data is requested -------------------------------------------
   if (totals) {
@@ -109,7 +108,7 @@ get_national_data <- function(country = NULL, totals = FALSE, source = "ecdc"){
     
     data <- data %>%
       dplyr::group_by(country) %>%
-      tidyr::fill(population_2019, un_region, .direction = "up") %>%
+      tidyr::fill(population_2019, un_region, .direction = "updown") %>%
       dplyr::ungroup()
     
     data <- data %>%
@@ -129,7 +128,7 @@ get_national_data <- function(country = NULL, totals = FALSE, source = "ecdc"){
     
     data <- data %>%
       dplyr::group_by(country) %>%
-      tidyr::fill(who_region, un_region, .direction = "up") %>%
+      tidyr::fill(who_region, un_region, .direction = "updown") %>%
       dplyr::ungroup()
     
     data <- data %>%

--- a/R/national.R
+++ b/R/national.R
@@ -12,7 +12,7 @@
 #' @importFrom readr read_csv
 #' @importFrom httr GET write_disk
 #' @importFrom readxl read_excel
-#' @importFrom dplyr mutate rename select arrange filter group_by ungroup
+#' @importFrom dplyr mutate rename select arrange filter
 #' @importFrom countrycode countryname
 #'
 #'

--- a/R/national.R
+++ b/R/national.R
@@ -12,7 +12,7 @@
 #' @importFrom readr read_csv
 #' @importFrom httr GET write_disk
 #' @importFrom readxl read_excel
-#' @importFrom dplyr mutate rename select arrange filter
+#' @importFrom dplyr mutate rename select arrange filter group_by ungroup
 #' @importFrom countrycode countryname
 #'
 #'
@@ -42,12 +42,19 @@ get_ecdc_cases <- function(){
     dplyr::mutate(cases_new = ifelse(cases_new < 0, 0, cases_new),
                   country = stringr::str_replace_all(country, "_", " "),
                   country = countrycode::countryname(country, destination = "country.name.en", warn = FALSE),
+                  iso_code = ifelse(country == "Namibia", "NA", iso_code),
                   un_region = countrycode::countrycode(iso_code, origin = "iso2c", destination = "un.region.name", warn = FALSE),
                   # Correct for Kosovo
-                  un_region = ifelse(iso_code == "XK", "Europe", un_region))
+                  un_region = ifelse(iso_code == "XK", "Europe", un_region),
+                  # Correct of UK
+                  un_region = ifelse(iso_code == "UK", "Europe", un_region),
+                  # Correct for Greece
+                  un_region = ifelse(iso_code == "EL", "Europe", un_region),
+                  # Correct for Taiwan
+                  un_region = ifelse(iso_code == "TW", "Asia", un_region))
+
   
   return(data)
-  
 }
 
 
@@ -83,7 +90,6 @@ get_who_cases <- function() {
                   country = ifelse(iso_code == "XK", "Kosovo", country))
   
   return(who)
-  
 }
 
 

--- a/tests/testthat/test-get_national_data.R
+++ b/tests/testthat/test-get_national_data.R
@@ -50,3 +50,35 @@ test_that("get_who_cases works as expected", {
   expect_equal(ncol(who), 8)
   
 })
+
+
+test_that("get_ecdc_cases returns a region for every country", {
+  skip_on_cran()
+  
+  library(dplyr)
+  
+  all_countries <- get_national_data(source = "ecdc")
+  
+  all_countries <- all_countries %>%  
+    dplyr::filter(is.na(un_region)) %>% 
+    dplyr::group_by(country) %>% 
+    dplyr::tally()
+  
+  expect_true(nrow(all_countries) == 0)
+})
+
+
+test_that("get_who_cases returns a region for every country", {
+  skip_on_cran()
+  
+  library(dplyr)
+  
+  all_countries <- get_national_data(source = "who")
+  
+  all_countries <- all_countries %>%  
+    dplyr::filter(is.na(un_region), !is.na(country)) %>% 
+    dplyr::group_by(country) %>% 
+    dplyr::tally()
+  
+  expect_true(nrow(all_countries) == 0)
+})


### PR DESCRIPTION
This PR resolves the issue of not all countries having assigned regions as flagged in #68 by @tjtnew.

There were two issues in play. 

1. ECDC data uses a European standard ISO code (I think this is a new change) that has several differences from what `countrycode` supports. Resolved this using a manual check for 4 instances. 
2. In `get_national_data` countries should have had any missing regions checked and filled if present for any dates. This was coded as an up directional fill when it should really have been bidirectional. This issue impacted both the WHO and ECDC data sets. 

PR also adds tests based on the reprex in #68 to flag if this issue occurs in the future. CRAN check run locally with no issues.