### PR TITLE
UK deaths data

### DIFF
--- a/R/get_regional_data.R
+++ b/R/get_regional_data.R
@@ -147,9 +147,8 @@ get_regional_data <- function(country, totals = FALSE, include_level_2_regions =
   # Rename the region column to country-specific --------------------------------------
   if (localise_regions) {
     data <- rename_region_column(data, country)
+    data <- rename_region_code_column(data, country)
   }
-  
-  data <- rename_region_code_column(data, country)
   
   return(tibble::tibble(data))
 }

--- a/R/get_regional_data.R
+++ b/R/get_regional_data.R
@@ -147,8 +147,9 @@ get_regional_data <- function(country, totals = FALSE, include_level_2_regions =
   # Rename the region column to country-specific --------------------------------------
   if (localise_regions) {
     data <- rename_region_column(data, country)
-    data <- rename_region_code_column(data, country)
   }
+  
+  data <- rename_region_code_column(data, country)
   
   return(tibble::tibble(data))
 }

--- a/R/uk.R
+++ b/R/uk.R
@@ -32,11 +32,15 @@ get_uk_regional_cases_only_level_1 <- function() {
                                       newCasesByPublishDate),
                   cases_total = ifelse(stringr::str_detect(areaCode, "^E"), 
                                       cumCasesBySpecimenDate,
-                                      cumCasesByPublishDate)) %>%
-    # Deaths (28 day), hospitalisations and tested variables are consistent across nations
-    dplyr::rename(deaths_new = newDeaths28DaysByPublishDate,
-                  deaths_total = cumDeaths28DaysByPublishDate,
-                  hosp_new = newAdmissions,
+                                      cumCasesByPublishDate),
+                  deaths_new = ifelse(stringr::str_detect(areaCode, "^E"), 
+                                      newDeaths28DaysByDeathDate,
+                                      newDeaths28DaysByPublishDate),
+                  deaths_total = ifelse(stringr::str_detect(areaCode, "^E"), 
+                                        cumDeaths28DaysByDeathDate,
+                                        cumDeaths28DaysByPublishDate)) %>%
+    # Hospitalisations and tested variables are consistent across nations
+    dplyr::rename(hosp_new = newAdmissions,
                   hosp_total = cumAdmissions,
                   tested_new = newTestsByPublishDate,
                   tested_total = cumTestsByPublishDate,
@@ -77,11 +81,15 @@ get_uk_regional_cases_with_level_2 <- function() {
                                      newCasesByPublishDate),
                   cases_total = ifelse(stringr::str_detect(areaCode, "^E"), 
                                        cumCasesBySpecimenDate,
-                                       cumCasesByPublishDate)) %>%
+                                       cumCasesByPublishDate),
+                  deaths_new = ifelse(stringr::str_detect(areaCode, "^E"), 
+                                      newDeaths28DaysByDeathDate,
+                                      newDeaths28DaysByPublishDate),
+                  deaths_total = ifelse(stringr::str_detect(areaCode, "^E"), 
+                                        cumDeaths28DaysByDeathDate,
+                                        cumDeaths28DaysByPublishDate)) %>%
     # Hospitalisations and tested variables are consistent across nations
-    dplyr::rename(deaths_new = newDeaths28DaysByPublishDate,
-                  deaths_total = cumDeaths28DaysByPublishDate,
-                  hosp_new = newAdmissions,
+    dplyr::rename(hosp_new = newAdmissions,
                   hosp_total = cumAdmissions,
                   tested_new = newTestsByPublishDate,
                   tested_total = cumTestsByPublishDate,
@@ -137,8 +145,10 @@ get_uk_data <- function(filters, progress_bar = FALSE) {
     "newCasesBySpecimenDate", "cumCasesBySpecimenDate",
     # Cases by date of report
     "newCasesByPublishDate", "cumCasesByPublishDate",
-    # deaths
+    # deaths by date of report
     "newDeaths28DaysByPublishDate", "cumDeaths28DaysByPublishDate",
+    # deaths by date of death
+    "newDeaths28DaysByDeathDate", "cumDeaths28DaysByDeathDate",
     # Tests - all
     "newTestsByPublishDate", "cumTestsByPublishDate",
     # Hospital - admissions


### PR DESCRIPTION
English regions only have deaths available by date of death.
- Adding as 2 new variables to data import (newDeaths28DaysByDeathDate and cumulative)
- Updating the "deaths_new" and "deaths_total" columns (as with cases)
  - Regions are by date of death, nations are by date of report


(Also reverts commit in PR #69 for localised region codes. PR closed)