### PR TITLE
Convert to api v2 UK

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covidregionaldata
 Title: Subnational Data for the Covid-19 Outbreak
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: c(person(given = "Sam Abbott",
            role = c("aut", "cre"),
            email = "sam.abbott@lshtm.ac.uk",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# covidregionaldata 0.8.0 
+# covidregionaldata 0.8.2
 
-This release contains fixes to keep data sources current and adapt to upstream changes but adds no new features. 
+## Package updates
+
+* Updates the API backend used to extract UK data to V2. Adds a release date variable which can be used to return data releases from specified dates rather than the latest snapshot.
 
 # covidregionaldata 0.7.0 
 

--- a/R/uk.R
+++ b/R/uk.R
@@ -60,6 +60,9 @@ get_uk_regional_cases_only_level_1 <- function(nhsregions = FALSE, release_date 
     if (is.null(release_date)) {
       release_date <- Sys.Date() - 1
     }
+    if (release_date < (Sys.Date() - 14)) {
+      stop("Data by NHS regions is only available in archived form for the last 14 days")
+    }
     message("Arranging data by NHS region. 
 Also adding new variable: hosp_new_first_admissions. This is NHS data for first hospital admissions, which excludes readmissions. This is available for England and English regions only.")
     # Download NHS xlsx

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -45,7 +45,7 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
   skip_on_cran()
   
   adm_1_data <- get_uk_regional_cases_only_level_1()
-  adm_2_data <- covidregionaldata:::get_uk_regional_cases_with_level_2()
+  adm_2_data <- get_uk_regional_cases_with_level_2()
   
   expect_equal(length(unique(na.omit(adm_1_data$region_level_1))), 13)
   expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 49)

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -50,3 +50,13 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
   expect_equal(length(unique(na.omit(adm_1_data$region_level_1))), 13)
   expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 200)
 })
+
+test_that("get_uk_regional_cases returns data by date of release", {
+  adm_1_data <- get_uk_regional_cases_only_level_1(release_date = "2020-09-01")
+  nhsregions_data <- get_uk_regional_cases_only_level_1(release_date = "2020-09-01", 
+                                                        nhsregions = TRUE)
+  adm_2_data <- get_uk_regional_cases_with_level_2(release_date = "2020-09-01")
+  expect_equal(max(adm_1_data$date), as.Date("2020-09-01"))
+  expect_equal(max(nhsregions_data$date), as.Date("2020-09-01"))
+  expect_equal(max(adm_2_data$date), as.Date("2020-09-01"))
+})

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -45,10 +45,10 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
   skip_on_cran()
   
   adm_1_data <- get_uk_regional_cases_only_level_1()
-  adm_2_data <- get_uk_regional_cases_with_level_2()
+  adm_2_data <- covidregionaldata:::get_uk_regional_cases_with_level_2()
   
   expect_equal(length(unique(na.omit(adm_1_data$region_level_1))), 13)
-  expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 200)
+  expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 49)
 })
 
 test_that("get_uk_regional_cases returns data by date of release", {

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -48,7 +48,7 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
   adm_2_data <- get_uk_regional_cases_with_level_2()
   
   expect_equal(length(unique(na.omit(adm_1_data$region_level_1))), 13)
-  expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 49)
+  expect_gt(length(unique(na.omit(adm_2_data$region_level_2))), 48)
 })
 
 test_that("get_uk_regional_cases returns data by date of release", {

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -53,10 +53,11 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
 
 test_that("get_uk_regional_cases returns data by date of release", {
   adm_1_data <- get_uk_regional_cases_only_level_1(release_date = "2020-09-01")
-  nhsregions_data <- get_uk_regional_cases_only_level_1(release_date = "2020-09-01", 
+  nhsregions_data <- get_uk_regional_cases_only_level_1(release_date = Sys.Date() - 13, 
                                                         nhsregions = TRUE)
   adm_2_data <- get_uk_regional_cases_with_level_2(release_date = "2020-09-01")
   expect_equal(max(adm_1_data$date), as.Date("2020-09-01"))
-  expect_equal(max(nhsregions_data$date), as.Date("2020-09-01"))
+  expect_equal(max(nhsregions_data$date), Sys.Date() - 13)
   expect_equal(max(adm_2_data$date), as.Date("2020-09-01"))
+  expect_error(get_uk_regional_cases_only_level_1(release_date = "2020-11-01", nhsregions = TRUE))
 })


### PR DESCRIPTION
This PR converts UK data extraction to V2 of the API (which is currently undocumented but can be explored [here](https://coronavirus.data.gov.uk/details/download)). 

This may enable the addition of new variables but the full list and documentation has yet to be published. 

This PR also adds the ability to extract archived UK data either from the V2 API since April or for NHS regions for the last two weeks. This may be helpful when evaluating forecasting models (as it is important to fit to the data available at the time and not the final data set) and when exploring evidence for data truncation. 

Tests have been extended for this new feature but in addition the test for the number of available UTLAs had to be dropped from 200 0> 49. It is unclear what has led to this change but it appears to be present in the data.