### PR TITLE
UK NHS archive data fix

### DIFF
--- a/R/uk.R
+++ b/R/uk.R
@@ -60,8 +60,8 @@ get_uk_regional_cases_only_level_1 <- function(nhsregions = FALSE, release_date 
     if (is.null(release_date)) {
       release_date <- Sys.Date() - 1
     }
-    if (release_date < (Sys.Date() - 14)) {
-      stop("Data by NHS regions is only available in archived form for the last 14 days")
+    if (release_date < (Sys.Date() - 7)) {
+      stop("Data by NHS regions is only available in archived form for the last 7 days")
     }
     message("Arranging data by NHS region. 
 Also adding new variable: hosp_new_first_admissions. This is NHS data for first hospital admissions, which excludes readmissions. This is available for England and English regions only.")
@@ -229,9 +229,9 @@ get_uk_data <- function(filters, release_date = NULL) {
     "newAdmissions", "cumAdmissions", 
     #
     # --- Additional non-standard variables --- #
-    # Hospital
-    "cumAdmissionsByAge", "covidOccupiedMVBeds", 
-    "hospitalCases", "plannedCapacityByPublishDate",
+    # # # Hospital
+    # "cumAdmissionsByAge", "covidOccupiedMVBeds",
+    # "hospitalCases", "plannedCapacityByPublishDate",
     # Tests by pillar
     "newPillarOneTestsByPublishDate", "newPillarTwoTestsByPublishDate", 
     "newPillarThreeTestsByPublishDate", "newPillarFourTestsByPublishDate"

--- a/R/utils.R
+++ b/R/utils.R
@@ -379,4 +379,5 @@ utils::globalVariables(c(".", ":=", "AnzahlFall", "Area type", "Specimen date", 
                          "hosp_new_first_admissions",
                          "iso_3166_2", "min_date", "max_date", "iso_na", 
                          "cases_new_na", "cases_total_na", "deaths_new_na", "deaths_total_na",
-                         "ENTRY_DATE", "DATE_IMPLEMENTED"))
+                         "ENTRY_DATE", "DATE_IMPLEMENTED",
+                         "cases_weekly", "deaths_weekly"))

--- a/tests/testthat/test-get_uk_regional_cases.R
+++ b/tests/testthat/test-get_uk_regional_cases.R
@@ -53,11 +53,11 @@ test_that("get_uk_regional_cases returns correct numbers of regions", {
 
 test_that("get_uk_regional_cases returns data by date of release", {
   adm_1_data <- get_uk_regional_cases_only_level_1(release_date = "2020-09-01")
-  nhsregions_data <- get_uk_regional_cases_only_level_1(release_date = Sys.Date() - 13, 
+  nhsregions_data <- get_uk_regional_cases_only_level_1(release_date = Sys.Date() - 6, 
                                                         nhsregions = TRUE)
   adm_2_data <- get_uk_regional_cases_with_level_2(release_date = "2020-09-01")
   expect_equal(max(adm_1_data$date), as.Date("2020-09-01"))
-  expect_equal(max(nhsregions_data$date), Sys.Date() - 13)
+  expect_equal(max(nhsregions_data$date), Sys.Date() - 6)
   expect_equal(max(adm_2_data$date), as.Date("2020-09-01"))
   expect_error(get_uk_regional_cases_only_level_1(release_date = "2020-11-01", nhsregions = TRUE))
 })


### PR DESCRIPTION
- Looks like NHS data archived only for last 7 days (instead of 14). Checked by trial and error - couldn't find clear evidence of this policy so could be wrong/change. This was causing UK testthat checks to fail
- Stopped downloading admissions by age and MV beds. These variables are given for national level only (not regional) and in long (not wide) format which had trouble slotting in to the standardised structure for returning dataframes. Removed as not currently used by us (I think), but can reinstate: if so, suggest re-writing as an option which returns a more suitable custom dataset structure