### PR TITLE
Refactor how regions are manipulated in Lithuania code

### DIFF
--- a/R/get_region_codes.R
+++ b/R/get_region_codes.R
@@ -285,36 +285,10 @@ get_italy_region_codes <- function() {
 }
 
 #' Lithuanian region codes
-#' @importFrom tibble tribble
-#'
+#' @return (NULL) These are already presented by the `get_data` function
+#' 
 get_lithuania_region_codes <- function() {
-
-  # The following code, adjusted from a version for France, was initially used
-  # to create lookup tables of Lithuanian municipality and country codes. These
-  # were then adjusted to match the format used by the Official Statistics
-  # Portal in their open data and are left as hard-coded tibbles. These codes
-  # have not changed in ten years.
-
-  # level_2_codes_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:LT"
-  # level_2_codes_table <- level_2_codes_url %>%
-  #   xml2::read_html() %>%
-  #   rvest::html_nodes(xpath = '//*[@id="mw-content-text"]/div/table') %>%
-  #   rvest::html_table(fill = TRUE)
-  region_codes <- tibble::tribble(
-    ~level_1_region_code,            ~region,                   ~region_en,
-    "LT-AL",             "Alytaus apskritis",              "Alytus County",
-    "LT-KU",               "Kauno apskritis",              "Kaunas County",
-    "LT-KL",      "Klaip\u0117dos apskritis",       "Klaip\u0117da County",
-    "LT-MR",   "Marijampol\u0117s apskritis",    "Marijampol\u0117 County",
-    "LT-PN", "Panev\u0117\u017eio apskritis", "Panev\u0117\u017eys County",
-    "LT-SA",   "\u0160iauli\u0173 apskritis",       "\u0160iauliai County",
-    "LT-TA",       "Taurag\u0117s apskritis",        "Taurag\u0117 County",
-    "LT-TE",    "Tel\u0161i\u0173 apskritis",        "Tel\u0161iai County",
-    "LT-UT",              "Utenos apskritis",               "Utena County",
-    "LT-VL",            "Vilniaus apskritis",             "Vilnius County",
-         NA,                   "nenustatyta",                   "unstated"
-  )
-  return(region_codes)
+  return (NULL)
 }
 
 #' US region codes
@@ -451,86 +425,9 @@ get_france_level_2_codes <- function() {
   return(NULL)
 }
 
-#' Lithuania level 2 codes
-#' @importFrom tibble tribble
+#' Lithuania level 2 codes (Included in original function)
 get_lithuania_level_2_codes <- function() {
-  # The following code, adjusted from a version for France, was initially used to
-  # create lookup tables of Lithuanian municipality and country codes.
-  # These were then adjusted to match the format used by the
-  # Official Statistics Portal in their open data and are left as
-  # hard-coded tibbles. These codes have not changed in ten years.
-
-  # level_2_codes_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:LT"
-  # level_2_codes_table <- level_2_codes_url %>%
-  #   xml2::read_html() %>%
-  #   rvest::html_nodes(xpath = '//*[@id="mw-content-text"]/div/table') %>%
-  #   rvest::html_table(fill = TRUE)
-
-  region_codes <- tibble::tribble(
-    ~level_2_region_code,               ~region,       ~region_nomin,            ~region_type,
-    "LT-01",     "Akmen\u0117s r. sav.",            "Akmen\u0117", "district municipality",
-    "LT-02",     "Alytaus m. sav.",   "Alytaus miestas",     "city municipality",
-    "LT-03",     "Alytaus r. sav.",            "Alytus", "district municipality",
-    "LT-04",    "Anyk\u0161\u010di\u0173 r. sav.",         "Anyk\u0161\u010diai", "district municipality",
-    "LT-05",       "Bir\u0161tono sav.",          "Bir\u0161tono",          "municipality",
-    "LT-06",       "Bir\u017e\u0173 r. sav.",            "Bir\u017eai", "district municipality",
-    "LT-07",    "Druskinink\u0173 sav.",      "Druskininkai",          "municipality",
-    "LT-08",      "Elektr\u0117n\u0173 sav.",        "Elektr\u0117nai",          "municipality",
-    "LT-09",   "Ignalinos r. sav.",          "Ignalina", "district municipality",
-    "LT-10",     "Jonavos r. sav.",            "Jonava", "district municipality",
-    "LT-11",    "Joni\u0161kio r. sav.",          "Joni\u0161kis", "district municipality",
-    "LT-12",    "Jurbarko r. sav.",         "Jurbarkas", "district municipality",
-    "LT-13", "Kai\u0161iadori\u0173 r. sav.",       "Kai\u0161iadorys", "district municipality",
-    "LT-14",     "Kalvarijos sav.",        "Kalvarijos",          "municipality",
-    "LT-16",       "Kauno r. sav.",            "Kaunas", "district municipality",
-    "LT-15",       "Kauno m. sav.",     "Kauno miestas",     "city municipality",
-    "LT-17",    "Kazl\u0173 R\u016bdos sav.",       "Kazl\u0173 R\u016bdos",          "municipality",
-    "LT-18",    "K\u0117daini\u0173 r. sav.",         "K\u0117dainiai", "district municipality",
-    "LT-19",      "Kelm\u0117s r. sav.",             "Kelm\u0117", "district municipality",
-    "LT-21",   "Klaip\u0117dos r. sav.",          "Klaip\u0117da", "district municipality",
-    "LT-20",   "Klaip\u0117dos m. sav.", "Klaip\u0117dos miestas",     "city municipality",
-    "LT-22",   "Kretingos r. sav.",          "Kretinga", "district municipality",
-    "LT-23",    "Kupi\u0161kio r. sav.",          "Kupi\u0161kis", "district municipality",
-    "LT-24",     "Lazdij\u0173 r. sav.",          "Lazdijai", "district municipality",
-    "LT-25",   "Marijampol\u0117s sav.",       "Marijampol\u0117", "district municipality",
-    "LT-26",    "Ma\u017eeiki\u0173 r. sav.",         "Ma\u017eeikiai", "district municipality",
-    "LT-27",      "Mol\u0117t\u0173 r. sav.",           "Mol\u0117tai", "district municipality",
-    "LT-28",       "Neringos sav.",           "Neringa",          "municipality",
-    "LT-29",        "Pag\u0117gi\u0173 sav.",          "Pag\u0117giai",          "municipality",
-    "LT-30",    "Pakruojo r. sav.",         "Pakruojis", "district municipality",
-    "LT-31",    "Palangos m. sav.",  "Palangos miestas",     "city municipality",
-    "LT-32",   "Panev\u0117\u017eio m. sav.", "Panev\u0117\u017eio miestas",     "city municipality",
-    "LT-33",   "Panev\u0117\u017eio r. sav.",         "Panev\u0117\u017eys", "district municipality",
-    "LT-34",    "Pasvalio r. sav.",          "Pasvalys", "district municipality",
-    "LT-35",     "Plung\u0117s r. sav.",            "Plung\u0117", "district municipality",
-    "LT-36",      "Prien\u0173 r. sav.",           "Prienai", "district municipality",
-    "LT-37", "Radvili\u0161kio r. sav.",       "Radvili\u0161kis", "district municipality",
-    "LT-38",    "Raseini\u0173 r. sav.",         "Raseiniai", "district municipality",
-    "LT-39",        "Rietavo sav.",           "Rietavo",          "municipality",
-    "LT-40",    "Roki\u0161kio r. sav.",          "Roki\u0161kis", "district municipality",
-    "LT-41",       "\u0160aki\u0173 r. sav.",            "\u0160akiai", "district municipality",
-    "LT-42",  "\u0160al\u010dinink\u0173 r. sav.",       "\u0160al\u010dininkai", "district municipality",
-    "LT-44",     "\u0160iauli\u0173 r. sav.",          "\u0160iauliai", "district municipality",
-    "LT-43",     "\u0160iauli\u0173 m. sav.",   "\u0160iauli\u0173 miestas",     "city municipality",
-    "LT-45",     "\u0160ilal\u0117s r. sav.",            "\u0160ilal\u0117", "district municipality",
-    "LT-46",     "\u0160ilut\u0117s r. sav.",            "\u0160ilut\u0117", "district municipality",
-    "LT-47",    "\u0160irvint\u0173 r. sav.",         "\u0160irvintos", "district municipality",
-    "LT-48",      "Skuodo r. sav.",           "Skuodas", "district municipality",
-    "LT-49",  "\u0160ven\u010dioni\u0173 r. sav.",        "\u0160ven\u010dionys", "district municipality",
-    "LT-50",    "Taurag\u0117s r. sav.",           "Taurag\u0117", "district municipality",
-    "LT-51",      "Tel\u0161i\u0173 r. sav.",           "Tel\u0161iai", "district municipality",
-    "LT-52",       "Trak\u0173 r. sav.",            "Trakai", "district municipality",
-    "LT-53",    "Ukmerg\u0117s r. sav.",           "Ukmerg\u0117", "district municipality",
-    "LT-54",      "Utenos r. sav.",             "Utena", "district municipality",
-    "LT-55",     "Var\u0117nos r. sav.",            "Var\u0117na", "district municipality",
-    "LT-56", "Vilkavi\u0161kio r. sav.",       "Vilkavi\u0161kis", "district municipality",
-    "LT-57",    "Vilniaus m. sav.",  "Vilniaus miestas",     "city municipality",
-    "LT-58",    "Vilniaus r. sav.",           "Vilnius", "district municipality",
-    "LT-59",       "Visagino sav.",         "Visaginas",          "municipality",
-    "LT-60",      "Zaras\u0173 r. sav.",           "Zarasai", "district municipality",
-    NA,         "nenustatyta",          "unstated",                      NA
-  )
-  return (region_codes)
+  return (NULL)
 }
 
 #' US level 2 codes (FIPS) (Included in original function)

--- a/R/get_region_codes.R
+++ b/R/get_region_codes.R
@@ -285,7 +285,8 @@ get_italy_region_codes <- function() {
 }
 
 #' Lithuanian region codes
-#' @return (NULL) These are already presented by the `get_data` function
+#' @return (NULL) These are already presented by the
+#' `get_lithuania_regional_cases_with_level_2` function
 #' 
 get_lithuania_region_codes <- function() {
   return (NULL)

--- a/R/lithuania.R
+++ b/R/lithuania.R
@@ -40,7 +40,7 @@ get_lithuania_regional_cases_only_level_1 <-
       all_osp_fields,
       death_definition
     ) %>%
-      dplyr::group_by(date, region_level_1) %>%
+      dplyr::group_by(date, region_level_1, level_1_region_code) %>%
       dplyr::summarise(dplyr::across(tidyselect::vars_select_helpers$where(is.numeric), sum)) %>%
       dplyr::mutate(region_level_1 = if_else(is.na(.data$region_level_1),
         "Lietuva", .data$region_level_1

--- a/R/lithuania.R
+++ b/R/lithuania.R
@@ -17,10 +17,10 @@
 #' @importFrom tidyselect vars_select_helpers
 get_lithuania_regional_cases_only_level_1 <-
   function(
-    national_data = FALSE,
-    all_osp_fields = FALSE,
-    death_definition = "of",
-    recovered_definition = "official") {
+           national_data = FALSE,
+           all_osp_fields = FALSE,
+           death_definition = "of",
+           recovered_definition = "official") {
     # Lithuania only publishes data at the municipality level. To provide
     # data for the level 1 regions (Counties, Apskritis) we get the municipality
     # level data and aggregate it according to municipality
@@ -43,7 +43,7 @@ get_lithuania_regional_cases_only_level_1 <-
       dplyr::group_by(date, region_level_1) %>%
       dplyr::summarise(dplyr::across(tidyselect::vars_select_helpers$where(is.numeric), sum)) %>%
       dplyr::mutate(region_level_1 = if_else(is.na(.data$region_level_1),
-                                             "Lietuva", .data$region_level_1
+        "Lietuva", .data$region_level_1
       )) %>%
       dplyr::ungroup()
     # Fix percentages, where necessary
@@ -219,6 +219,9 @@ get_lithuania_regional_cases_only_level_1 <-
 #'
 #'
 #' @seealso [get_lithuania_regional_cases_only_level_1()]
+#' 
+#' @md
+#' 
 #' @importFrom dplyr %>% filter select mutate full_join left_join rename bind_rows
 #' @importFrom lubridate as_date ymd
 #' @importFrom xml2 read_html
@@ -226,14 +229,12 @@ get_lithuania_regional_cases_only_level_1 <-
 #' @importFrom tibble tibble
 #' @importFrom rlang .data
 #' @importFrom tidyselect last_col
-#'
-#' @md
+#' 
 get_lithuania_regional_cases_with_level_2 <-
   function(national_data = FALSE,
            all_osp_fields = FALSE,
            death_definition = "of",
-           recovered_definition = "official") 
-  {
+           recovered_definition = "official") {
     # The following code, adjusted from a version for France, was initially
     # used to create lookup tables of Lithuanian municipality and country
     # codes.
@@ -245,91 +246,91 @@ get_lithuania_regional_cases_with_level_2 <-
     #   xml2::read_html() %>%
     #   rvest::html_nodes(xpath = '//*[@id=\"mw-content-text\"]/div/table') %>%
     #   rvest::html_table(fill = TRUE)
-    municipality_county_lookup <- tibble::tribble(
-      ~region_level_2, ~region_level_1,
-      "Akmen\u0117s r. sav.", "\u0160iauli\u0173 apskritis",
-      "Alytaus m. sav.", "Alytaus apskritis",
-      "Alytaus r. sav.", "Alytaus apskritis",
-      "Anyk\u0161\u010di\u0173 r. sav.", "Utenos apskritis",
-      "Bir\u0161tono sav.", "Kauno apskritis",
-      "Bir\u017e\u0173 r. sav.", "Panev\u0117\u017eio apskritis",
-      "Druskinink\u0173 sav.", "Alytaus apskritis",
-      "Elektr\u0117n\u0173 sav.", "Vilniaus apskritis",
-      "Ignalinos r. sav.", "Utenos apskritis",
-      "Jonavos r. sav.", "Kauno apskritis",
-      "Joni\u0161kio r. sav.", "\u0160iauli\u0173 apskritis",
-      "Jurbarko r. sav.", "Taurag\u0117s apskritis",
-      "Kai\u0161iadori\u0173 r. sav.", "Kauno apskritis",
-      "Kalvarijos sav.", "Marijampol\u0117s apskritis",
-      "Kauno r. sav.", "Kauno apskritis",
-      "Kauno m. sav.", "Kauno apskritis",
-      "Kazl\u0173 R\u016bdos sav.", "Marijampol\u0117s apskritis",
-      "K\u0117daini\u0173 r. sav.", "Kauno apskritis",
-      "Kelm\u0117s r. sav.", "\u0160iauli\u0173 apskritis",
-      "Klaip\u0117dos r. sav.", "Klaip\u0117dos apskritis",
-      "Klaip\u0117dos m. sav.", "Klaip\u0117dos apskritis",
-      "Kretingos r. sav.", "Klaip\u0117dos apskritis",
-      "Kupi\u0161kio r. sav.", "Panev\u0117\u017eio apskritis",
-      "Lazdij\u0173 r. sav.", "Alytaus apskritis",
-      "Marijampol\u0117s sav.", "Marijampol\u0117s apskritis",
-      "Ma\u017eeiki\u0173 r. sav.", "Tel\u0161i\u0173 apskritis",
-      "Mol\u0117t\u0173 r. sav.", "Utenos apskritis",
-      "Neringos sav.", "Klaip\u0117dos apskritis",
-      "Pag\u0117gi\u0173 sav.", "Taurag\u0117s apskritis",
-      "Pakruojo r. sav.", "\u0160iauli\u0173 apskritis",
-      "Palangos m. sav.", "Klaip\u0117dos apskritis",
-      "Panev\u0117\u017eio m. sav.", "Panev\u0117\u017eio apskritis",
-      "Panev\u0117\u017eio r. sav.", "Panev\u0117\u017eio apskritis",
-      "Pasvalio r. sav.", "Panev\u0117\u017eio apskritis",
-      "Plung\u0117s r. sav.", "Tel\u0161i\u0173 apskritis",
-      "Prien\u0173 r. sav.", "Kauno apskritis",
-      "Radvili\u0161kio r. sav.", "\u0160iauli\u0173 apskritis",
-      "Raseini\u0173 r. sav.", "Kauno apskritis",
-      "Rietavo sav.", "Tel\u0161i\u0173 apskritis",
-      "Roki\u0161kio r. sav.", "Panev\u0117\u017eio apskritis",
-      "\u0160aki\u0173 r. sav.", "Marijampol\u0117s apskritis",
-      "\u0160al\u010dinink\u0173 r. sav.", "Vilniaus apskritis",
-      "\u0160iauli\u0173 r. sav.", "\u0160iauli\u0173 apskritis",
-      "\u0160iauli\u0173 m. sav.", "\u0160iauli\u0173 apskritis",
-      "\u0160ilal\u0117s r. sav.", "Taurag\u0117s apskritis",
-      "\u0160ilut\u0117s r. sav.", "Klaip\u0117dos apskritis",
-      "\u0160irvint\u0173 r. sav.", "Vilniaus apskritis",
-      "Skuodo r. sav.", "Klaip\u0117dos apskritis",
-      "\u0160ven\u010dioni\u0173 r. sav.", "Vilniaus apskritis",
-      "Taurag\u0117s r. sav.", "Taurag\u0117s apskritis",
-      "Tel\u0161i\u0173 r. sav.", "Tel\u0161i\u0173 apskritis",
-      "Trak\u0173 r. sav.", "Vilniaus apskritis",
-      "Ukmerg\u0117s r. sav.", "Vilniaus apskritis",
-      "Utenos r. sav.", "Utenos apskritis",
-      "Var\u0117nos r. sav.", "Alytaus apskritis",
-      "Vilkavi\u0161kio r. sav.", "Marijampol\u0117s apskritis",
-      "Vilniaus m. sav.", "Vilniaus apskritis",
-      "Vilniaus r. sav.", "Vilniaus apskritis",
-      "Visagino sav.", "Utenos apskritis",
-      "Zaras\u0173 r. sav.", "Utenos apskritis",
-      "nenustatyta", "nenustatyta",
-      "Unknown", "Unknown"
+
+    region_lookup_table <- tibble::tribble(
+      ~region_level_2, ~level_2_region_code, ~region_level_1, ~level_1_region_code, ~region_level_1_en, ~region_level_2_type,
+      "Alytaus m. sav.", "LT-02", "Alytaus apskritis", "LT-AL", "Alytus County", "city municipality",
+      "Alytaus r. sav.", "LT-03", "Alytaus apskritis", "LT-AL", "Alytus County", "district municipality",
+      "Druskinink\u0173 sav.", "LT-07", "Alytaus apskritis", "LT-AL", "Alytus County", "municipality",
+      "Lazdij\u0173 r. sav.", "LT-24", "Alytaus apskritis", "LT-AL", "Alytus County", "district municipality",
+      "Var\u0117nos r. sav.", "LT-55", "Alytaus apskritis", "LT-AL", "Alytus County", "district municipality",
+      "Bir\u0161tono sav.", "LT-05", "Kauno apskritis", "LT-KU", "Kaunas County", "municipality",
+      "Jonavos r. sav.", "LT-10", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Kai\u0161iadori\u0173 r. sav.", "LT-13", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Kauno r. sav.", "LT-16", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Kauno m. sav.", "LT-15", "Kauno apskritis", "LT-KU", "Kaunas County", "city municipality",
+      "K\u0117daini\u0173 r. sav.", "LT-18", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Prien\u0173 r. sav.", "LT-36", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Raseini\u0173 r. sav.", "LT-38", "Kauno apskritis", "LT-KU", "Kaunas County", "district municipality",
+      "Klaip\u0117dos r. sav.", "LT-21", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "district municipality",
+      "Klaip\u0117dos m. sav.", "LT-20", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "city municipality",
+      "Kretingos r. sav.", "LT-22", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "district municipality",
+      "Neringos sav.", "LT-28", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "municipality",
+      "Palangos m. sav.", "LT-31", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "city municipality",
+      "\u0160ilut\u0117s r. sav.", "LT-46", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "district municipality",
+      "Skuodo r. sav.", "LT-48", "Klaip\u0117dos apskritis", "LT-KL", "Klaip\u0117da County", "district municipality",
+      "Kalvarijos sav.", "LT-14", "Marijampol\u0117s apskritis", "LT-MR", "Marijampol\u0117 County", "municipality",
+      "Kazl\u0173 R\u016bdos sav.", "LT-17", "Marijampol\u0117s apskritis", "LT-MR", "Marijampol\u0117 County", "municipality",
+      "Marijampol\u0117s sav.", "LT-25", "Marijampol\u0117s apskritis", "LT-MR", "Marijampol\u0117 County", "district municipality",
+      "\u0160aki\u0173 r. sav.", "LT-41", "Marijampol\u0117s apskritis", "LT-MR", "Marijampol\u0117 County", "district municipality",
+      "Vilkavi\u0161kio r. sav.", "LT-56", "Marijampol\u0117s apskritis", "LT-MR", "Marijampol\u0117 County", "district municipality",
+      "Bir\u017e\u0173 r. sav.", "LT-06", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "district municipality",
+      "Kupi\u0161kio r. sav.", "LT-23", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "district municipality",
+      "Panev\u0117\u017eio m. sav.", "LT-32", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "city municipality",
+      "Panev\u0117\u017eio r. sav.", "LT-33", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "district municipality",
+      "Pasvalio r. sav.", "LT-34", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "district municipality",
+      "Roki\u0161kio r. sav.", "LT-40", "Panev\u0117\u017eio apskritis", "LT-PN", "Panev\u0117\u017eys County", "district municipality",
+      "Akmen\u0117s r. sav.", "LT-01", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "Joni\u0161kio r. sav.", "LT-11", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "Kelm\u0117s r. sav.", "LT-19", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "Pakruojo r. sav.", "LT-30", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "Radvili\u0161kio r. sav.", "LT-37", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "\u0160iauli\u0173 r. sav.", "LT-44", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "district municipality",
+      "\u0160iauli\u0173 m. sav.", "LT-43", "\u0160iauli\u0173 apskritis", "LT-SA", "\u0160iauliai County", "city municipality",
+      "Jurbarko r. sav.", "LT-12", "Taurag\u0117s apskritis", "LT-TA", "Taurag\u0117 County", "district municipality",
+      "Pag\u0117gi\u0173 sav.", "LT-29", "Taurag\u0117s apskritis", "LT-TA", "Taurag\u0117 County", "municipality",
+      "\u0160ilal\u0117s r. sav.", "LT-45", "Taurag\u0117s apskritis", "LT-TA", "Taurag\u0117 County", "district municipality",
+      "Taurag\u0117s r. sav.", "LT-50", "Taurag\u0117s apskritis", "LT-TA", "Taurag\u0117 County", "district municipality",
+      "Ma\u017eeiki\u0173 r. sav.", "LT-26", "Tel\u0161i\u0173 apskritis", "LT-TE", "Tel\u0161iai County", "district municipality",
+      "Plung\u0117s r. sav.", "LT-35", "Tel\u0161i\u0173 apskritis", "LT-TE", "Tel\u0161iai County", "district municipality",
+      "Rietavo sav.", "LT-39", "Tel\u0161i\u0173 apskritis", "LT-TE", "Tel\u0161iai County", "municipality",
+      "Tel\u0161i\u0173 r. sav.", "LT-51", "Tel\u0161i\u0173 apskritis", "LT-TE", "Tel\u0161iai County", "district municipality",
+      "Anyk\u0161\u010di\u0173 r. sav.", "LT-04", "Utenos apskritis", "LT-UT", "Utena County", "district municipality",
+      "Ignalinos r. sav.", "LT-09", "Utenos apskritis", "LT-UT", "Utena County", "district municipality",
+      "Mol\u0117t\u0173 r. sav.", "LT-27", "Utenos apskritis", "LT-UT", "Utena County", "district municipality",
+      "Utenos r. sav.", "LT-54", "Utenos apskritis", "LT-UT", "Utena County", "district municipality",
+      "Visagino sav.", "LT-59", "Utenos apskritis", "LT-UT", "Utena County", "municipality",
+      "Zaras\u0173 r. sav.", "LT-60", "Utenos apskritis", "LT-UT", "Utena County", "district municipality",
+      "Elektr\u0117n\u0173 sav.", "LT-08", "Vilniaus apskritis", "LT-VL", "Vilnius County", "municipality",
+      "\u0160al\u010dinink\u0173 r. sav.", "LT-42", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "\u0160irvint\u0173 r. sav.", "LT-47", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "\u0160ven\u010dioni\u0173 r. sav.", "LT-49", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "Trak\u0173 r. sav.", "LT-52", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "Ukmerg\u0117s r. sav.", "LT-53", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "Vilniaus m. sav.", "LT-57", "Vilniaus apskritis", "LT-VL", "Vilnius County", "city municipality",
+      "Vilniaus r. sav.", "LT-58", "Vilniaus apskritis", "LT-VL", "Vilnius County", "district municipality",
+      "Unknown", NA, "Unknown", NA, NA, NA
     )
-    
+
     # Advertise the fine documentation.
     message("Use ?get_lithuania_regional_cases_with_level_2() for more information on this dataset")
-    
+
     # Read data --------------------------------------------------------------------
     cases_url <- "https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0.csv"
     osp_data <- csv_reader(file = cases_url)
-    
+
     # Process two params which let us switch what OSP fields are returned
     # for the number of deaths and the number of recovered cases.
     #
     # death_definition : default is "of"
     death_field <- switch(death_definition,
-                          of = "daily_deaths_def1",
-                          daily_deaths_def1 = "daily_deaths_def1",
-                          with = "daily_deaths_def2",
-                          daily_deaths_def2 = "daily_deaths_def2",
-                          after = "daily_deaths_def3",
-                          daily_deaths_def3 = "daily_deaths_def3",
-                          having_had = "daily_deaths_def3"
+      of = "daily_deaths_def1",
+      daily_deaths_def1 = "daily_deaths_def1",
+      with = "daily_deaths_def2",
+      daily_deaths_def2 = "daily_deaths_def2",
+      after = "daily_deaths_def3",
+      daily_deaths_def3 = "daily_deaths_def3",
+      having_had = "daily_deaths_def3"
     )
     # If death_definition doesn't match one of our possibilities, it will
     # return NULL
@@ -341,15 +342,15 @@ get_lithuania_regional_cases_with_level_2 <-
       ))
       death_field <- "daily_deaths_def1"
     }
-    
+
     # recovered_definition : default is "official"
     recovered_field <- switch(recovered_definition,
-                              official = "recovered_de_jure",
-                              recovered_de_jure = "recovered_de_jure",
-                              de_jure = "recovered_de_jure",
-                              recovered_sttstcl = "recovered_sttstcl",
-                              statistical = "recovered_sttstcl",
-                              estimated = "recovered_sttstcl"
+      official = "recovered_de_jure",
+      recovered_de_jure = "recovered_de_jure",
+      de_jure = "recovered_de_jure",
+      recovered_sttstcl = "recovered_sttstcl",
+      statistical = "recovered_sttstcl",
+      estimated = "recovered_sttstcl"
     )
     # If recovered_definition doesn't match one of our possibilities, it will
     # return NULL
@@ -361,52 +362,52 @@ get_lithuania_regional_cases_with_level_2 <-
       ))
       recovered_field <- "recovered_de_jure"
     }
-    
+
     # Build "unassigned" data by subtracting the aggregate from the countrywide
     # total provided for Lietuva
-    
+
     # Get relevant column names for differences (i.e. not percentages
     # or qualitative)
     sum_cols <- names(select(osp_data, "population":tidyselect::last_col()))
     sum_cols <- sum_cols[!grepl("prc|map_colors", sum_cols)]
-    
+
     # Take the difference between national and sum of counties' data
     unassigned <- osp_data %>%
       dplyr::mutate(national = ifelse(.data$municipality_name == "Lietuva", "national", "municipality")) %>%
       dplyr::group_by(date, .data$national) %>%
       dplyr::summarise(across(tidyselect::all_of(sum_cols), ~ sum(.x, na.rm = TRUE))) %>%
       dplyr::mutate(across(tidyselect::all_of(sum_cols), ~ dplyr::lead(.x, 1) - .x),
-                    municipality_name = "Unknown",
-                    ab_prc_day =
-                      dplyr::if_else(
-                        .data$ab_tot_day == 0, 0,
-                        .data$ab_pos_day / .data$ab_tot_day
-                      ),
-                    ag_prc_day =
-                      dplyr::if_else(
-                        .data$ag_tot_day == 0, 0,
-                        .data$ag_pos_day / .data$ag_tot_day
-                      ),
-                    pcr_prc_day =
-                      dplyr::if_else(
-                        .data$pcr_tot_day == 0, 0,
-                        .data$pcr_pos_day / .data$pcr_tot_day
-                      ),
-                    dgn_prc_day =
-                      dplyr::if_else(
-                        .data$dgn_tot_day == 0, 0,
-                        .data$dgn_pos_day / .data$dgn_tot_day
-                      ),
-                    map_colors = NA_character_
+        municipality_name = "Unknown",
+        ab_prc_day =
+          dplyr::if_else(
+            .data$ab_tot_day == 0, 0,
+            .data$ab_pos_day / .data$ab_tot_day
+          ),
+        ag_prc_day =
+          dplyr::if_else(
+            .data$ag_tot_day == 0, 0,
+            .data$ag_pos_day / .data$ag_tot_day
+          ),
+        pcr_prc_day =
+          dplyr::if_else(
+            .data$pcr_tot_day == 0, 0,
+            .data$pcr_pos_day / .data$pcr_tot_day
+          ),
+        dgn_prc_day =
+          dplyr::if_else(
+            .data$dgn_tot_day == 0, 0,
+            .data$dgn_pos_day / .data$dgn_tot_day
+          ),
+        map_colors = NA_character_
       ) %>%
       dplyr::filter(.data$national == "municipality") %>%
       dplyr::select(-.data$national)
-    
+
     # Join unknown locations to main dataset
     osp_data_w_unassigned <- dplyr::bind_rows(
       osp_data %>% select(-.data$object_id, -.data$municipality_code), unassigned
     )
-    
+
     # Exclude national data based on user param (default = FALSE)
     if (!national_data) {
       osp_data_w_unassigned <-
@@ -415,7 +416,7 @@ get_lithuania_regional_cases_with_level_2 <-
           !.data$municipality_name == "Lietuva"
         )
     }
-    
+
     cases_data <- osp_data_w_unassigned %>%
       dplyr::mutate(
         date = lubridate::as_date(date),
@@ -428,9 +429,10 @@ get_lithuania_regional_cases_with_level_2 <-
         cases_total = .data$cumulative_totals,
         region_level_2 = .data$municipality_name
       ) %>%
-      dplyr::left_join(municipality_county_lookup, by = c("region_level_2")) %>%
+      dplyr::left_join(region_lookup_table, by = c("region_level_2")) %>%
       dplyr::select(
         date, region_level_1, region_level_2,
+        level_1_region_code, level_2_region_code, 
         cases_new, cases_total, deaths_new,
         tested_new, recovered_total,
         dplyr::everything()
@@ -442,6 +444,7 @@ get_lithuania_regional_cases_with_level_2 <-
       cases_data <- cases_data %>%
         dplyr::select(
           date, region_level_1, region_level_2,
+          level_1_region_code, level_2_region_code,
           cases_new, cases_total, deaths_new, tested_new, recovered_total
         )
     }

--- a/R/lithuania.R
+++ b/R/lithuania.R
@@ -1,15 +1,18 @@
 #' Lithuania Regional Daily COVID-19 Count Data - County
 #' @inherit get_lithuania_regional_cases_with_level_2
 #'
-#' @description Extracts daily COVID-19 data for Lithuania, stratified by county (apskritis)
-#' and municipality (savivaldybe). Some Lithuanian municipalities share names, there being both a
-#' Vilnius city municipality (m. sav.) and a Vilnius regional municipality (r. sav.)
+#' @description Extracts daily COVID-19 data for Lithuania,
+#' stratified by county (apskritis) and municipality (savivaldybe).
+#' Some Lithuanian municipalities share names, there being both a
+#' Vilnius city municipality (m. sav.) and a Vilnius regional
+#' municipality (r. sav.)
 #'
 #' Data available at \url{https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0}.
 #'
 #' It is loaded and then sanitised.
 #'
-#' @return A data frame of COVID cases by county in Lithuania, ready to be used by \code{get_regional_data()}.
+#' @return A data frame of COVID cases by county in Lithuania,
+#' ready to be used by \code{get_regional_data()}.
 #'
 #' @seealso [get_lithuania_regional_cases_with_level_2()]
 #' @md
@@ -22,26 +25,18 @@ get_lithuania_regional_cases_only_level_1 <-
            death_definition = "of",
            recovered_definition = "official") {
     # Lithuania only publishes data at the municipality level. To provide
-    # data for the level 1 regions (Counties, Apskritis) we get the municipality
-    # level data and aggregate it according to municipality
-    # level_1_lookup <- tibble::tibble(level_1_region_code = c("LT-AL", "LT-KU", "LT-KL", "LT-MR", "LT-PN",
-    #                                        "LT-SA", "LT-TA", "LT-TE", "LT-UT", "LT-VL", NA_character_),
-    #                region_level_1 = c("Alytaus apskritis",
-    #                                   "Kauno apskritis", "Klaip\u0117dos apskritis", "Marijampol\u0117s apskritis",
-    #                                   "Panev\u0117\u017eio apskritis", "\u0160iauli\u0173 apskritis", "Taurag\u0117s apskritis",
-    #                                   "Tel\u0161i\u0173 apskritis", "Utenos apskritis", "Vilniaus apskritis", "nenustatyta"),
-    #                region_level_1_en = c("Alytus County", "Kaunas County",
-    #                                      "Klaip\u0117da County", "Marijampol\u0117 County", "Panev\u0117\u017eys County",
-    #                                      "\u0160iauliai County", "Taurag\u0117 County", "Tel\u0161iai County", "Utena County",
-    #                                      "Vilnius County", "unstated"))
-    #
+    # data for the level 1 regions (Counties, Apskritis) we get the
+    # municipality level data and aggregate it according to municipality
+
     county_data <- get_lithuania_regional_cases_with_level_2(
       national_data,
       all_osp_fields,
       death_definition
     ) %>%
       dplyr::group_by(date, region_level_1, level_1_region_code) %>%
-      dplyr::summarise(dplyr::across(tidyselect::vars_select_helpers$where(is.numeric), sum)) %>%
+      dplyr::summarise(
+        dplyr::across(tidyselect::vars_select_helpers$where(is.numeric),
+                      sum)) %>%
       dplyr::mutate(region_level_1 = if_else(is.na(.data$region_level_1),
         "Lietuva", .data$region_level_1
       )) %>%
@@ -219,34 +214,20 @@ get_lithuania_regional_cases_only_level_1 <-
 #'
 #'
 #' @seealso [get_lithuania_regional_cases_only_level_1()]
-#' 
+#'
 #' @md
-#' 
+#'
 #' @importFrom dplyr %>% filter select mutate full_join left_join rename bind_rows
 #' @importFrom lubridate as_date ymd
-#' @importFrom xml2 read_html
-#' @importFrom rvest html_nodes html_table
-#' @importFrom tibble tibble
+#' @importFrom tibble tribble
 #' @importFrom rlang .data
 #' @importFrom tidyselect last_col
-#' 
+#'
 get_lithuania_regional_cases_with_level_2 <-
   function(national_data = FALSE,
            all_osp_fields = FALSE,
            death_definition = "of",
            recovered_definition = "official") {
-    # The following code, adjusted from a version for France, was initially
-    # used to create lookup tables of Lithuanian municipality and country
-    # codes.
-    # These were then adjusted to match the format used by the
-    # Official Statistics Portal in their open data and are left as
-    # hard-coded tibbles. These codes have not changed in ten years.
-    # level_2_codes_url <- "https://en.wikipedia.org/wiki/ISO_3166-2:LT"
-    # level_2_codes_table <- level_2_codes_url %>%
-    #   xml2::read_html() %>%
-    #   rvest::html_nodes(xpath = '//*[@id=\"mw-content-text\"]/div/table') %>%
-    #   rvest::html_table(fill = TRUE)
-
     region_lookup_table <- tibble::tribble(
       ~region_level_2, ~level_2_region_code, ~region_level_1, ~level_1_region_code, ~region_level_1_en, ~region_level_2_type,
       "Alytaus m. sav.", "LT-02", "Alytaus apskritis", "LT-AL", "Alytus County", "city municipality",
@@ -315,7 +296,7 @@ get_lithuania_regional_cases_with_level_2 <-
     # Advertise the fine documentation.
     message("Use ?get_lithuania_regional_cases_with_level_2() for more information on this dataset")
 
-    # Read data --------------------------------------------------------------------
+    # Read data
     cases_url <- "https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0.csv"
     osp_data <- csv_reader(file = cases_url)
 
@@ -373,10 +354,13 @@ get_lithuania_regional_cases_with_level_2 <-
 
     # Take the difference between national and sum of counties' data
     unassigned <- osp_data %>%
-      dplyr::mutate(national = ifelse(.data$municipality_name == "Lietuva", "national", "municipality")) %>%
+      dplyr::mutate(national = ifelse(.data$municipality_name == "Lietuva",
+                                      "national", "municipality")) %>%
       dplyr::group_by(date, .data$national) %>%
-      dplyr::summarise(across(tidyselect::all_of(sum_cols), ~ sum(.x, na.rm = TRUE))) %>%
-      dplyr::mutate(across(tidyselect::all_of(sum_cols), ~ dplyr::lead(.x, 1) - .x),
+      dplyr::summarise(across(tidyselect::all_of(sum_cols),
+                              ~ sum(.x, na.rm = TRUE))) %>%
+      dplyr::mutate(across(tidyselect::all_of(sum_cols),
+                           ~ dplyr::lead(.x, 1) - .x),
         municipality_name = "Unknown",
         ab_prc_day =
           dplyr::if_else(
@@ -405,7 +389,8 @@ get_lithuania_regional_cases_with_level_2 <-
 
     # Join unknown locations to main dataset
     osp_data_w_unassigned <- dplyr::bind_rows(
-      osp_data %>% select(-.data$object_id, -.data$municipality_code), unassigned
+      osp_data %>% select(-.data$object_id, -.data$municipality_code),
+      unassigned
     )
 
     # Exclude national data based on user param (default = FALSE)
@@ -432,7 +417,7 @@ get_lithuania_regional_cases_with_level_2 <-
       dplyr::left_join(region_lookup_table, by = c("region_level_2")) %>%
       dplyr::select(
         date, region_level_1, region_level_2,
-        level_1_region_code, level_2_region_code, 
+        level_1_region_code, level_2_region_code,
         cases_new, cases_total, deaths_new,
         tested_new, recovered_total,
         dplyr::everything()
@@ -445,13 +430,16 @@ get_lithuania_regional_cases_with_level_2 <-
         dplyr::select(
           date, region_level_1, region_level_2,
           level_1_region_code, level_2_region_code,
-          cases_new, cases_total, deaths_new, tested_new, recovered_total
+          cases_new, cases_total, deaths_new,
+          tested_new, recovered_total
         )
     }
-    ## This is the list of fields which we're trying to generate, copied from get_regional_data.R
-    # date, region_level_2, level_2_region_code, region_level_1, level_1_region_code,
+    ## This is the list of fields which we're trying to generate, copied
+    # from get_regional_data.R:
+    # date, region_level_2, level_2_region_code,
+    # region_level_1, level_1_region_code,
     # cases_new, cases_total, deaths_new, deaths_total,
     # recovered_new, recovered_total, hosp_new, hosp_total,
-    # tested_new, tested_total, dplyr::everything())
+    # tested_new, tested_total, dplyr::everything()
     return(cases_data)
   }

--- a/man/get_lithuania_level_2_codes.Rd
+++ b/man/get_lithuania_level_2_codes.Rd
@@ -2,10 +2,10 @@
 % Please edit documentation in R/get_region_codes.R
 \name{get_lithuania_level_2_codes}
 \alias{get_lithuania_level_2_codes}
-\title{Lithuania level 2 codes}
+\title{Lithuania level 2 codes (Included in original function)}
 \usage{
 get_lithuania_level_2_codes()
 }
 \description{
-Lithuania level 2 codes
+Lithuania level 2 codes (Included in original function)
 }

--- a/man/get_lithuania_region_codes.Rd
+++ b/man/get_lithuania_region_codes.Rd
@@ -6,6 +6,9 @@
 \usage{
 get_lithuania_region_codes()
 }
+\value{
+(NULL) These are already presented by the \code{get_data} function
+}
 \description{
 Lithuanian region codes
 }

--- a/man/get_lithuania_region_codes.Rd
+++ b/man/get_lithuania_region_codes.Rd
@@ -7,7 +7,8 @@
 get_lithuania_region_codes()
 }
 \value{
-(NULL) These are already presented by the \code{get_data} function
+(NULL) These are already presented by the
+\code{get_lithuania_regional_cases_with_level_2} function
 }
 \description{
 Lithuanian region codes

--- a/man/get_lithuania_regional_cases_only_level_1.Rd
+++ b/man/get_lithuania_regional_cases_only_level_1.Rd
@@ -30,12 +30,15 @@ the statistical estimate provided by OSP. Should be \code{"official"}
 or \code{"statistical"}. (Defaults to \code{"official"}.)}
 }
 \value{
-A data frame of COVID cases by county in Lithuania, ready to be used by \code{get_regional_data()}.
+A data frame of COVID cases by county in Lithuania,
+ready to be used by \code{get_regional_data()}.
 }
 \description{
-Extracts daily COVID-19 data for Lithuania, stratified by county (apskritis)
-and municipality (savivaldybe). Some Lithuanian municipalities share names, there being both a
-Vilnius city municipality (m. sav.) and a Vilnius regional municipality (r. sav.)
+Extracts daily COVID-19 data for Lithuania,
+stratified by county (apskritis) and municipality (savivaldybe).
+Some Lithuanian municipalities share names, there being both a
+Vilnius city municipality (m. sav.) and a Vilnius regional
+municipality (r. sav.)
 
 Data available at \url{https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0}.
 


### PR DESCRIPTION
I've changed how regions and region codes are used internally to get from the source (which provides municipality names) to what we need (knowing which municipalities are in which counties, and applying ISO:3166-2 codes for municipalities and counties). This should be invisible to the end-user but is cleaner and should ask for fewer `left_join` calls.