### PR TITLE
typo fix + suggestions

### DIFF
--- a/R/shared-methods.R
+++ b/R/shared-methods.R
@@ -1,24 +1,24 @@
-#' Check country and regions are avaliable and set up country class
+#' Check country and regions are available and set up country class
 #'
 #' @description Check data for the requested country and region
-#' is avaliable and return an initialised region class for that country.
+#' is available and return an initialised region class for that country.
 #' @inheritParams get_regional_data
-#' @return The target countries specific object if avaliable, e.g. [Italy()]
+#' @return The target countries specific object if available, e.g. [Italy()]
 #' @rdname check_country_available
 #' @export
 #' @examples
 #' check_country_available(country = "Italy")
-check_country_available <- function(country = character(), level = "1",
+check_country_available <- function(country = character(), level = 1,
                                     totals = FALSE, localise = TRUE,
                                     verbose = TRUE, steps = FALSE, ...) {
   stopifnot(is.character(country))
-  stopifnot(is.character(level))
+  level <- as.character(level)
 
   # check we have data for desired country
-  avaliable_sources <- covidregionaldata::region_codes$country
-  if (!(tolower(country) %in% avaliable_sources)) {
+  available_sources <- covidregionaldata::region_codes$country
+  if (!(tolower(country) %in% available_sources)) {
     stop(
-      paste("No data avaliable for country'", country, "'.")
+      paste0("No data available for country '", country, "'.")
     )
   }
   regionClass <- get(country)
@@ -81,8 +81,8 @@ DataClass <- R6::R6Class(
 
       if (self$verbose) {
         message(
-          "Getting data for ", self$country,
-          " at ", tar_level_name, " administrative region"
+          "Processing data for ", self$country,
+          " by ", tar_level_name
         )
       }
 

--- a/man/check_country_available.Rd
+++ b/man/check_country_available.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/shared-methods.R
 \name{check_country_available}
 \alias{check_country_available}
-\title{Check country and regions are avaliable and set up country class}
+\title{Check country and regions are available and set up country class}
 \usage{
 check_country_available(
   country = character(),
-  level = "1",
+  level = 1,
   totals = FALSE,
   localise = TRUE,
   verbose = TRUE,
@@ -40,11 +40,11 @@ steps be kept and output in a list.}
 \item{...}{additional arguments to pass to country specific functionality.}
 }
 \value{
-The target countries specific object if avaliable, e.g. \code{\link[=Italy]{Italy()}}
+The target countries specific object if available, e.g. \code{\link[=Italy]{Italy()}}
 }
 \description{
 Check data for the requested country and region
-is avaliable and return an initialised region class for that country.
+is available and return an initialised region class for that country.
 }
 \examples{
 check_country_available(country = "Italy")

--- a/tests/testthat/test-check_country_available.R
+++ b/tests/testthat/test-check_country_available.R
@@ -13,20 +13,6 @@ test_that(
   }
 )
 test_that(
-  "Test error is thrown for numeric level",
-  {
-    expect_error(
-      check_country_available(
-        country = "1", level = 1,
-        totals = FALSE, localise = TRUE,
-        verbose = FALSE, steps = FALSE
-      ),
-      "is.character(level) is not TRUE",
-      fixed = TRUE
-    )
-  }
-)
-test_that(
   "Test error is thrown for unknown country/source",
   {
     expect_error(
@@ -35,13 +21,13 @@ test_that(
         totals = FALSE, localise = TRUE,
         verbose = FALSE, steps = FALSE
       ),
-      "No data avaliable for country' amadeupcountry '.",
+      "No data available for country 'amadeupcountry'.",
       fixed = TRUE
     )
   }
 )
 test_that(
-  "Test error is thrown when level not avaliable for data",
+  "Test error is thrown when level not available for data",
   {
     expect_error(
       check_country_available(


### PR DESCRIPTION
suggestions only - minor edits to `shared-methods.R`
- returns message: "Getting data for ... at ... administrative region"
  - quite wordy, suggest replace with "getting data for ... by ..." which should still make sense
  - replaced "getting" with "Processing" to be clear we aren't returning the raw data directly
- arg : `level = "2"`
  - giving this arg as a character is not very intuitive - used numeric
- `available` was misspelled in several places