### PR TITLE
Germany GitHub Actions

### DIFF
--- a/.github/workflows/germany.yaml
+++ b/.github/workflows/germany.yaml
@@ -1,0 +1,45 @@
+on:
+  schedule:
+    - cron: '2 0 * * *'
+
+name: Germany
+
+jobs:
+  Germany:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_dev_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name:
+        run: |
+          options("testDownload" = TRUE)
+          options("testSource" = "germany")
+          testthat::test_file("test-regional-datasets.R", reporter = c("summary", "fail")) 
+        shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Subnational regions are only available in some countries. See the package docume
 | ECDC  |  [![ECDC](https://github.com/epiforecasts/covidregionaldata/workflows/ECDC/badge.svg)](https://github.com/epiforecasts/covidregionaldata/actions/workflows/ecdc.yaml)    | *working* |
 | Mexico  |  [![Mexico](https://github.com/epiforecasts/covidregionaldata/workflows/Mexico/badge.svg)](https://github.com/epiforecasts/covidregionaldata/actions/workflows/mexico.yaml)    | *working* |
 | Italy  |  [![Italy](https://github.com/epiforecasts/covidregionaldata/workflows/Italy/badge.svg)](https://github.com/epiforecasts/covidregionaldata/actions/workflows/italy.yaml)    | *working* |
-
+| Germany  |  [![Germany](https://github.com/epiforecasts/covidregionaldata/workflows/Germany/badge.svg)](https://github.com/epiforecasts/covidregionaldata/actions/workflows/germany.yaml)    | *working* |
 
 ## Development
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -64,6 +64,7 @@ develVersion
 dir
 dmuijen
 docsearch
+DOI
 donnees
 DONTTEST
 DownZCSV
@@ -91,6 +92,7 @@ fribidi
 gb
 gcc
 geocoding
+germany
 getRversion
 ggplot
 github
@@ -225,6 +227,8 @@ subregion
 sudo
 summarise
 tessella
+testDownload
+testSource
 testthat
 tibble
 tidyr


### PR DESCRIPTION
This PR adds the Germany Github action missed in #172. It currently does nothing as the testing file has not yet been reimplemented. 