### PR TITLE
fixes bugs in new depreciation warnings

### DIFF
--- a/R/get_regional_data.R
+++ b/R/get_regional_data.R
@@ -45,9 +45,9 @@ get_regional_data <- function(country, level = "1", totals = FALSE,
       "covidregionaldata::get_regional_data(include_level_2_regions = )", "covidregionaldata::get_regional_data(level = )"
     )
     if (include_level_2_regions) {
-      level <- "1"
-    } else {
       level <- "2"
+    } else {
+      level <- "1"
     }
   }
 
@@ -65,9 +65,6 @@ get_regional_data <- function(country, level = "1", totals = FALSE,
     tolower(substr(country, 2, nchar(country)))
   )
 
-  if (include_level_2_regions) {
-    level <- "2"
-  }
   # check data availability and initiate country class if available
   region_class <- check_country_available(
     country = country, level = level,


### PR DESCRIPTION
Noticed some errors when I ran from dev after merge of #185 

1. `if (include_level_2_regions) {
    level <- "2"
  }` fails if `include_level_2_regions` is not set as a parameter with error: `Error in if (include_level_2_regions) { : 
  argument is not interpretable as logical`  

2. `if (include_level_2_regions) {
      level <- "1"
    } else {
      level <- "2"
    }
` Should this not be the other way around?