### PR TITLE
Fix Italy warning

### DIFF
--- a/R/Italy.R
+++ b/R/Italy.R
@@ -36,7 +36,7 @@ Italy <- R6::R6Class("Italy",
       }
       self$data$clean <- self$data$raw %>%
         mutate(
-          date = as_date(ymd_hms(.data$data)),
+          date = suppressWarnings(as_date(ymd_hms(.data$data))),
           region_level_1 = as.character(.data$denominazione_regione),
           cases_total = .data$totale_casi,
           deaths_total = .data$deceduti,


### PR DESCRIPTION
This PR fixes the warning seen when cleaning Italy data. 

This looks like a false warning from `dplyr` based on the use of `data` as a variable. Given that and after checking I have suppressed it. This could be dangerous if the date variable changes format but tests should catch this.