### PR TITLE
Check class bugfix 203

### DIFF
--- a/tests/testthat/test-check_country_class.R
+++ b/tests/testthat/test-check_country_class.R
@@ -1,8 +1,8 @@
-check_fields <- function(field, region_class) {
+check_fields <- function(field, region_class, country) {
   test_that(
     paste(
       "Expect", field, "is in",
-      class(region_class)[1], "public fields"
+      country, "public fields"
     ),
     {
       expect_true(field %in% names(region_class$public_fields))
@@ -10,11 +10,11 @@ check_fields <- function(field, region_class) {
   )
 }
 
-check_methods <- function(method, region_class) {
+check_methods <- function(method, region_class, country) {
   test_that(
     paste(
       "Expect", method, "is in",
-      class(region_class)[1], "public methods"
+      country, "public methods"
     ),
     {
       expect_true(method %in% names(region_class$public_methods))
@@ -29,12 +29,14 @@ check_country_class <- function(country) {
   purrr::walk(
     expected_public_fields,
     check_fields,
-    region_class
+    region_class,
+    country
   )
   purrr::walk(
     expected_public_methods,
     check_methods,
-    region_class
+    region_class,
+    country
   )
 }
 


### PR DESCRIPTION
Made a small change to the testing functions so they show the country name, trying to get this from the class didn't work as they were not initialized. If they are initialized then you can't get the public fields.

Fixes issue #203 