### PR TITLE
Make tests work with data$raw as list

### DIFF
--- a/tests/testthat/custom_tests/test-regional-dataset.R
+++ b/tests/testthat/custom_tests/test-regional-dataset.R
@@ -40,11 +40,14 @@ test_regional_dataset <- function(source, level, download = FALSE) {
   if (download) {
     test_that(paste0(data_name, " downloads sucessfully"), {
       region$download()
-      expect_s3_class(region$data$raw, "data.frame")
-      expect_true(nrow(region$data$raw) > 0)
-      expect_true(ncol(region$data$raw) >= 2)
+      purrr::walk(region$data$raw, function(data) {
+      expect_s3_class(data, "data.frame")
+      expect_true(nrow(data) > 0)
+      expect_true(ncol(data) >= 2)
+      }
     })
-    region$data$raw <- dplyr::slice_tail(region$data$raw, n = 1000)
+    region$data$raw <- purrr::map(region$data$raw, 
+                                  dplyr::slice_tail, n = 1000)
     saveRDS(region$data$raw, raw_path)
   } else {
     region$data$raw <- readRDS(raw_path)


### PR DESCRIPTION
Scoping PR to make tests work with `data$raw` as a list. Additional changes are needed in the UK where custom tests use the NHS dataset. This could probably be replaced by adding a custom step to our overall testing where tests on a dataset are run with and without optional arguments (probably some thinking required for this one). 

To activate these tests (once `data$raw` as a list has been implemented) they need to be run locally with `options(testDownload = TRUE)`. This may also highlight other changes that are needed that are hard to see currently. 