### PR TITLE
Alt data urls

### DIFF
--- a/R/Canada.R
+++ b/R/Canada.R
@@ -25,9 +25,9 @@ Canada <- R6::R6Class("Canada",
     supported_region_names = list("1" = "province"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2"),
-    #' @field data_url List of named links to raw data. The first, and
-    #' only entry, is be named main.
-    data_url = list(
+    #' @field common_data_urls List of named links to raw data that are common
+    #' across levels.
+    common_data_urls = list(
       "main" = "https://health-infobase.canada.ca/src/data/covidLive/covid19.csv" # nolint
     ),
     #' @field source_data_cols existing columns within the raw data

--- a/R/CountryTemplate.R
+++ b/R/CountryTemplate.R
@@ -25,9 +25,9 @@ CountryTemplate <- R6::R6Class("CountryTemplate", # rename to country name
     supported_region_names = list("1" = NA),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = NA),
-    #' @field data_url List of named links to raw data. The first, and
+    #' @field common_data_urls List of named links to raw data. The first, and
     #' sometimes only entry, should be named main
-    data_url = list(main = "url"),
+    common_data_urls = list(main = "url"),
     #' @field source_data_cols existing columns within the raw data
     source_data_cols = c("col_1", "col_2", "col_3", "etc."),
 

--- a/R/ECDC.R
+++ b/R/ECDC.R
@@ -26,9 +26,8 @@ ECDC <- R6::R6Class("ECDC",
     supported_region_names = list("1" = "country"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_code"),
-    #' @field data_url List of named links to raw data. The first, and
-    #' only entry, is be named main.
-    data_url = list(
+    #' @field common_data_urls List of named links to raw data.
+    common_data_urls = list(
       "main" = "https://opendata.ecdc.europa.eu/covid19/casedistribution/csv"
     ),
     #' @field source_data_cols existing columns within the raw data

--- a/R/Germany.R
+++ b/R/Germany.R
@@ -24,9 +24,9 @@ Germany <- R6::R6Class("Germany",
     supported_region_names = list("1" = "bundesland", "2" = "landkreis"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2"),
-    #' @field data_url List of named links to raw data. The first, and
+    #' @field common_data_urls List of named links to raw data. The first, and
     #' only entry, is be named main.
-    data_url = list(
+    common_data_urls = list(
       "main" = "https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv" # nolint
     ),
     #' @field source_data_cols existing columns within the raw data

--- a/R/Italy.R
+++ b/R/Italy.R
@@ -23,9 +23,9 @@ Italy <- R6::R6Class("Italy",
     supported_region_names = list("1" = "regioni"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2"),
-    #' @field data_url List of named links to raw data. The first, and
+    #' @field common_data_urls List of named links to raw data. The first, and
     #' only entry, is be named main.
-    data_url = list(
+    common_data_urls = list(
       "main" = "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv" # nolint
     ),
     #' @field source_data_cols existing columns within the raw data

--- a/R/Mexico.R
+++ b/R/Mexico.R
@@ -34,12 +34,15 @@ Mexico <- R6::R6Class("Mexico",
     supported_region_names = list("1" = "estados", "2" = "municipios"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2", "2" = "inegi"),
-    #' @field data_url List of named links to raw data. The first, and
-    #' only entry, is be named main.
-    data_url = list(
-      "main" = "https://datos.covid-19.conacyt.mx/",
-      "1" = "Downloads/filesDD.php?csvmun",
-      "2" = "Downloads/filesDD.php?csvaxd"
+    #' @field common_data_urls List of named links to raw data.
+    common_data_urls = list(
+      "main" = "https://datos.covid-19.conacyt.mx/"
+    ),
+    #' @field level_data_urls List of named links to raw data that are level
+    #' specific.
+    level_data_urls = list(
+      "1" = list("snippet" = "Downloads/filesDD.php?csvmun"),
+      "2" = list("snippet" = "Downloads/filesDD.php?csvaxd")
     ),
     #' @field source_data_cols existing columns within the raw data
     source_data_cols = c("cases_new", "deaths_new"),
@@ -67,8 +70,8 @@ Mexico <- R6::R6Class("Mexico",
     download = function() {
       . <- NULL
       script_url <- file.path(
-        self$data_url[["main"]],
-        self$data_url[[self$level]]
+        self$data_urls[["main"]],
+        self$data_urls[["snippet"]]
       )
 
       confirmed_url <- script_url %>%
@@ -92,7 +95,7 @@ Mexico <- R6::R6Class("Mexico",
       read_data <- function(target, new_name) {
         message_verbose(self$verbose, "Downloading ", new_name)
         dat <- csv_reader(
-          file.path(self$data_url[["main"]], target),
+          file.path(self$data_urls[["main"]], target),
           self$verbose
         )
 

--- a/R/UK.R
+++ b/R/UK.R
@@ -27,11 +27,15 @@ UK <- R6::R6Class("UK", # rename to country name
     supported_region_names = list("1" = "region", "2" = "authority"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2", "2" = "ons_region_code"),
-    #' @field data_url List of named links to raw data. The first, and
+    #' @field common_data_urls List of named links to raw data. The first, and
     #' only entry, is be named main.
-    data_url = list(
-      "main" = "https://api.coronavirus.data.gov.uk/v2/data",
-      "nhs_base_url" = "https://www.england.nhs.uk/statistics"
+    common_data_urls = list(
+      "main" = "https://api.coronavirus.data.gov.uk/v2/data"
+    ),
+    #' @field level_data_urls List of named links to raw data that are level
+    #' specific.
+    level_data_urls = list(
+      "1" = list("nhs_base_url" = "https://www.england.nhs.uk/statistics")
     ),
     #' @field source_data_cols existing columns within the raw data
     source_data_cols = list(
@@ -248,7 +252,7 @@ UK <- R6::R6Class("UK", # rename to country name
       csv_links <- map(
         1:(ceiling(length(self$source_data_cols) / 4)),
         ~ paste0(
-          self$data_url[["main"]], "?", unlist(filter), "&",
+          self$data_urls[["main"]], "?", unlist(filter), "&",
           paste(paste0(
             "metric=",
             self$source_data_cols[(1 + 4 * (. - 1)):min(
@@ -334,7 +338,7 @@ UK <- R6::R6Class("UK", # rename to country name
         England and English regions only."
       )
       nhs_url <- paste0(
-        self$data_url[["nhs_base_url"]],
+        self$data_urls[["nhs_base_url"]],
         "/wp-content/uploads/sites/2/",
         year(self$release_date), "/",
         ifelse(month(self$release_date) < 10,

--- a/R/WHO.R
+++ b/R/WHO.R
@@ -24,9 +24,9 @@ WHO <- R6::R6Class("WHO",
     supported_region_names = list("1" = "country"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_code"),
-    #' @field data_url List of named links to raw data. The first, and
+    #' @field common_data_urls List of named links to raw data. The first, and
     #' only entry, is be named main.
-    data_url = list(
+    common_data_urls = list(
       "main" = "https://covid19.who.int/WHO-COVID-19-global-data.csv"
     ),
     #' @field source_data_cols existing columns within the raw data

--- a/R/shared-methods.R
+++ b/R/shared-methods.R
@@ -166,7 +166,7 @@ DataClass <- R6::R6Class(
     #' of supplied data_urls.
     #' @importFrom purrr map
     download = function() {
-      self$data$raw <- map(self$data_url, csv_reader,
+      self$data$raw <- map(self$data_urls, csv_reader,
         verbose = self$verbose
       )
     },

--- a/R/shared-methods.R
+++ b/R/shared-methods.R
@@ -134,8 +134,10 @@ DataClass <- R6::R6Class(
     #' @field common_data_urls List of named links to raw data that are common
     #' across levels. The first entry should be named main.
     common_data_urls = list(),
-    #' @field level_data_urls List of named links to raw data that are level
-    #' specific. Any urls that share a name with a url from `common_data_urls`
+    #' @field level_data_urls List of named lists of named links to raw data
+    #' that are level specific. Any urls that share a name with a url from
+    #' `common_data_urls`. Each top level list should be named after a supported
+    #' supported level.
     #' will be selected preferentially.
     level_data_urls = list(),
     #' @field source_data_cols existing columns within the raw data

--- a/R/shared-methods.R
+++ b/R/shared-methods.R
@@ -88,6 +88,16 @@ initialise_dataclass <- function(self, level = "1",
   self$region_name <- self$supported_region_names[[self$level]]
   self$code_name <- self$supported_region_codes[[self$level]]
   self$set_region_codes()
+
+  if (!is.null(self$level_data_urls[[self$level]])) {
+    self$data_urls <- merge(
+      self$common_data_urls,
+      self$level_data_urls[[self$level]]
+    )
+  } else {
+    self$data_urls <- self$common_data_urls
+  }
+
   if (get) {
     self$get()
   }
@@ -119,9 +129,15 @@ DataClass <- R6::R6Class(
     code_name = NULL,
     #' @field codes_lookup string or tibble Region codes for the target country
     codes_lookup = list(),
-    #' @field data_url List of named links to raw data. The first, and
-    #' sometimes only entry, should be named main
-    data_url = list(),
+    #' @field data_urls List of named links to raw data.
+    data_urls = list(),
+    #' @field common_data_urls List of named links to raw data that are common
+    #' across levels. The first entry should be named main.
+    common_data_urls = list(),
+    #' @field level_data_urls List of named links to raw data that are level
+    #' specific. Any urls that share a name with a url from `common_data_urls`
+    #' will be selected preferentially.
+    level_data_urls = list(),
     #' @field source_data_cols existing columns within the raw data
     source_data_cols = c(),
     #' @field level target region level

--- a/man/Canada.Rd
+++ b/man/Canada.Rd
@@ -35,8 +35,8 @@ region$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
-only entry, is be named main.}
+\item{\code{common_data_urls}}{List of named links to raw data that are common
+across levels.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}
 }

--- a/man/DataClass.Rd
+++ b/man/DataClass.Rd
@@ -30,8 +30,14 @@ downloading, processing, and returning data.
 
 \item{\code{codes_lookup}}{string or tibble Region codes for the target country}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
-sometimes only entry, should be named main}
+\item{\code{data_urls}}{List of named links to raw data.}
+
+\item{\code{common_data_urls}}{List of named links to raw data that are common
+across levels. The first entry should be named main.}
+
+\item{\code{level_data_urls}}{List of named links to raw data that are level
+specific. Any urls that share a name with a url from \code{common_data_urls}
+will be selected preferentially.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}
 

--- a/man/DataClass.Rd
+++ b/man/DataClass.Rd
@@ -35,8 +35,10 @@ downloading, processing, and returning data.
 \item{\code{common_data_urls}}{List of named links to raw data that are common
 across levels. The first entry should be named main.}
 
-\item{\code{level_data_urls}}{List of named links to raw data that are level
-specific. Any urls that share a name with a url from \code{common_data_urls}
+\item{\code{level_data_urls}}{List of named lists of named links to raw data
+that are level specific. Any urls that share a name with a url from
+\code{common_data_urls}. Each top level list should be named after a supported
+supported level.
 will be selected preferentially.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}

--- a/man/ECDC.Rd
+++ b/man/ECDC.Rd
@@ -35,8 +35,7 @@ national$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
-only entry, is be named main.}
+\item{\code{common_data_urls}}{List of named links to raw data.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}
 }

--- a/man/Germany.Rd
+++ b/man/Germany.Rd
@@ -33,7 +33,7 @@ region$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
+\item{\code{common_data_urls}}{List of named links to raw data. The first, and
 only entry, is be named main.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}

--- a/man/Italy.Rd
+++ b/man/Italy.Rd
@@ -33,7 +33,7 @@ region$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
+\item{\code{common_data_urls}}{List of named links to raw data. The first, and
 only entry, is be named main.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}

--- a/man/Mexico.Rd
+++ b/man/Mexico.Rd
@@ -43,8 +43,10 @@ region$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
-only entry, is be named main.}
+\item{\code{common_data_urls}}{List of named links to raw data.}
+
+\item{\code{level_data_urls}}{List of named links to raw data that are level
+specific.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}
 }

--- a/man/UK.Rd
+++ b/man/UK.Rd
@@ -52,8 +52,11 @@ Uk$new(
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
+\item{\code{common_data_urls}}{List of named links to raw data. The first, and
 only entry, is be named main.}
+
+\item{\code{level_data_urls}}{List of named links to raw data that are level
+specific.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}
 

--- a/man/WHO.Rd
+++ b/man/WHO.Rd
@@ -33,7 +33,7 @@ national$return()
 
 \item{\code{supported_region_codes}}{A list of region codes in order of level.}
 
-\item{\code{data_url}}{List of named links to raw data. The first, and
+\item{\code{common_data_urls}}{List of named links to raw data. The first, and
 only entry, is be named main.}
 
 \item{\code{source_data_cols}}{existing columns within the raw data}


### PR DESCRIPTION
This PR demonstrates moving `data_urls` to a list based structure that is created at initialisation from `common_data_urls` (shared across levels) and `level_data_urls` which is stratified by level. It is based on discussions in #231 with @RichardMN using the nested implementation approach vs using a field per level. The advantage of this is nesting any number of levels and easily dispatching to the correct level without custom if else initialisation code. This is open for debate. 

I have checked all changes locally using `options(testDownload = TRUE)` and completed all other PR checks as specified.