### PR TITLE
Clean nolint in documentation and tidy Belgium region code column names

### DIFF
--- a/R/Belgium.R
+++ b/R/Belgium.R
@@ -4,9 +4,9 @@
 #'  and processing COVID-19 region level 1 and 2 data for Belgium.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv
-#' @source https://epistat.sciensano.be/Data/COVID19BE_HOSP.csv
-#' @source https://epistat.sciensano.be/Data/COVID19BE_MORT.csv
+#' @source \url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
+#' @source \url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
+#' @source \url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
 #' @export
 #' @examples
 #' \dontrun{
@@ -26,7 +26,10 @@ Belgium <- R6::R6Class("Belgium",
     supported_region_names = list("1" = "region",
                                   "2" = "province"),
     #' @field supported_region_codes A list of region codes in order of level.
-    supported_region_codes = list("1" = "iso_3166_2_region",
+    #' ISO 3166-2 codes are used for both region and province levels in
+    #' Belgium, and for provinces these are marked as being
+    #' `iso_3166_2_province`
+    supported_region_codes = list("1" = "iso_3166_2",
                                   "2" = "iso_3166_2_province"),
     #' @field common_data_urls List of named links to raw data that are common
     #' across levels.

--- a/R/Brazil.R
+++ b/R/Brazil.R
@@ -7,7 +7,7 @@
 #' Data available on Github, curated by Wesley Cota:
 #' DOI 10.1590/SciELOPreprints.362
 #'
-#' @source https://github.com/wcota/covid19br
+#' @source \url{https://github.com/wcota/covid19br}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Canada.R
+++ b/R/Canada.R
@@ -5,7 +5,7 @@
 #'
 #' Data is sourced from \url{https://health-infobase.canada.ca}.
 #' @details Inherits from `DataClass`
-#' @source https://health-infobase.canada.ca
+#' @source \url{https://health-infobase.canada.ca}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Colombia.R
+++ b/R/Colombia.R
@@ -3,7 +3,9 @@
 #'  and processing covid-19 region data for Colombia
 #'
 #' @details Inherits from `DataClass`
-#' @source https://raw.githubusercontent.com/danielcs88/colombia_covid-19/master/datos/cronologia.csv  # nolint
+# nolint start
+#' @source \url{https://raw.githubusercontent.com/danielcs88/colombia_covid-19/master/datos/cronologia.csv}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Cuba.R
+++ b/R/Cuba.R
@@ -3,7 +3,9 @@
 #'  and processing covid-19 region data for Cuba
 #'
 #' @details Inherits from `DataClass`
-#' @source https://covid19cubadata.github.io/data/covid19-casos.csv  # nolint
+# nolint start
+#' @source \url{https://covid19cubadata.github.io/data/covid19-casos.csv}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/ECDC.R
+++ b/R/ECDC.R
@@ -5,7 +5,7 @@
 #'  Disease Prevention and Control.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://opendata.ecdc.europa.eu/covid19/casedistribution/csv
+#' @source \url{https://opendata.ecdc.europa.eu/covid19/casedistribution/csv}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/France.R
+++ b/R/France.R
@@ -6,9 +6,9 @@
 #' @details Inherits from `DataClass`
 #'
 # nolint start
-#' @source https://www.data.gouv.fr/fr/datasets/r/406c6a23-e283-4300-9484-54e78c8ae675
-#' @source https://www.data.gouv.fr/fr/datasets/r/6fadff46-9efd-4c53-942a-54aca783c30c
-#' @source https://www.data.gouv.fr/fr/datasets/r/001aca18-df6a-45c8-89e6-f82d689e6c01
+#' @source \url{https://www.data.gouv.fr/fr/datasets/r/406c6a23-e283-4300-9484-54e78c8ae675}
+#' @source \url{https://www.data.gouv.fr/fr/datasets/r/6fadff46-9efd-4c53-942a-54aca783c30c}
+#' @source \url{https://www.data.gouv.fr/fr/datasets/r/001aca18-df6a-45c8-89e6-f82d689e6c01}
 # nolint end
 #' @export
 #' @examples

--- a/R/Germany.R
+++ b/R/Germany.R
@@ -4,7 +4,9 @@
 #'  and processing COVID-19 region level 1 and 2 data for Germany.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv  # nolint
+# nolint start
+#' @source \url{https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/India.R
+++ b/R/India.R
@@ -3,7 +3,7 @@
 #'  and processing covid-19 region data for India.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://api.covid19india.org/csv/latest/state_wise_daily.csv
+#' @source \url{https://api.covid19india.org/csv/latest/state_wise_daily.csv}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Italy.R
+++ b/R/Italy.R
@@ -3,7 +3,9 @@
 #'  and processing covid-19 region data for Italy.
 #'
 #' @details Inherits from `DataClass`
-#' @source \url{https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv  # nolint}
+# nolint start
+#' @source \url{https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Italy.R
+++ b/R/Italy.R
@@ -3,7 +3,7 @@
 #'  and processing covid-19 region data for Italy.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv  # nolint
+#' @source \url{https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv  # nolint}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/Lithuania.R
+++ b/R/Lithuania.R
@@ -116,7 +116,7 @@
 #' many of these are still ill).
 #'
 # nolint start
-#' @source https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0
+#' @source \url{https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0}
 # nolint end
 #' @examples
 #' \dontrun{

--- a/R/Mexico.R
+++ b/R/Mexico.R
@@ -14,7 +14,7 @@
 #'  Level 1 INEGI codes are the first 2 characters of Level 2 INEGI codes
 #'
 #' @details Inherits from `DataClass`
-#' @source https://datos.covid-19.conacyt.mx/#DownZCSV
+#' @source \url{https://datos.covid-19.conacyt.mx/#DownZCSV}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/SouthAfrica.R
+++ b/R/SouthAfrica.R
@@ -4,8 +4,8 @@
 #'
 #' @details Inherits from `DataClass`
 # nolint start
-#' @source https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv
-#' @source https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_deaths.csv
+#' @source \url{https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv}
+#' @source \url{https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_deaths.csv}
 # nolint end
 #' @export
 #' @examples

--- a/R/UK.R
+++ b/R/UK.R
@@ -8,7 +8,9 @@
 #' download from (release_date) and a geographical resolution (resolution).
 #'
 #' @details Inherits from `DataClass`
-#' @source https://coronavirus.data.gov.uk/details/download #nolint
+# nolint start
+#' @source \url{https://coronavirus.data.gov.uk/details/download}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{
@@ -303,10 +305,14 @@ UK <- R6::R6Class("UK", # rename to country name
     #' @description Download NHS data for level 1 regions
     #' Separate NHS data is available for "first" admissions, excluding
     #' readmissions. This is available for England + English regions only.
-    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/ # nolint
+    # nolint start
+    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+    # nolint end
     #'     Section 2, "2. Estimated new hospital cases"
     #' @return nhs data.frame of nhs regions
-    #' @source https://www.england.nhs.uk/statistics/wp-content/uploads/sites/2/ # nolint
+    # nolint start
+    #' @source \url{https://coronavirus.data.gov.uk/details/download}
+    # nolint end
     #' @importFrom lubridate year month
     #' @importFrom readxl read_excel cell_limits
     #' @importFrom dplyr %>%
@@ -355,7 +361,9 @@ UK <- R6::R6Class("UK", # rename to country name
     #' @description Add NHS data for level 1 regions
     #' Separate NHS data is available for "first" admissions, excluding
     #' readmissions. This is available for England + English regions only.
-    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/ # nolint
+    # nolint start
+    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+    # nolint end
     #'     Section 2, "2. Estimated new hospital cases"
     #' @importFrom lubridate year month
     #' @importFrom readxl read_excel cell_limits

--- a/R/UK.R
+++ b/R/UK.R
@@ -306,7 +306,7 @@ UK <- R6::R6Class("UK", # rename to country name
     #' Separate NHS data is available for "first" admissions, excluding
     #' readmissions. This is available for England + English regions only.
     # nolint start
-    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+    #'   See: \url{https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/}
     # nolint end
     #'     Section 2, "2. Estimated new hospital cases"
     #' @return nhs data.frame of nhs regions
@@ -362,7 +362,7 @@ UK <- R6::R6Class("UK", # rename to country name
     #' Separate NHS data is available for "first" admissions, excluding
     #' readmissions. This is available for England + English regions only.
     # nolint start
-    #'   See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+    #'   See: \url{https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/}
     # nolint end
     #'     Section 2, "2. Estimated new hospital cases"
     #' @importFrom lubridate year month

--- a/R/USA.R
+++ b/R/USA.R
@@ -3,8 +3,10 @@
 #'  and processing covid-19 region data for USA.
 #'
 #' @details Inherits from `DataClass`
-#' @source https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv # nolint
-#' @source https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv # nolint
+# nolint start
+#' @source \url{https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv}
+#' @source \url{https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv}
+# nolint end
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/WHO.R
+++ b/R/WHO.R
@@ -4,7 +4,7 @@
 #'  and processing covid-19 region data from the World Health Organisation
 #'
 #' @details Inherits from `DataClass`
-#' @source https://covid19.who.int/WHO-COVID-19-global-data.csv
+#' @source \url{https://covid19.who.int/WHO-COVID-19-global-data.csv}
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/get_interventions_data.R
+++ b/R/get_interventions_data.R
@@ -11,7 +11,7 @@
 #'  See: https://supertracker.spi.ox.ac.uk/policy-trackers/
 #'
 #' @return a dataframe of government interventions up to Dec 2020 from ACAPS
-#' @source https://www.acaps.org/covid-19-government-measures-dataset
+#' @source \url{https://www.acaps.org/covid-19-government-measures-dataset}
 #' @author Paul Campbell @paulcampbell91
 #'
 #' @keywords internal

--- a/R/get_linelist.R
+++ b/R/get_linelist.R
@@ -17,7 +17,7 @@
 #'  Should only certain variables (id, country, onset date, days' delay),
 #'  and observations (patients with a report delay) be returned
 #' @return A linelist of reported cases of Covid-19
-#' @source https://github.com/beoutbreakprepared/nCoV2019
+#' @source \url{https://github.com/beoutbreakprepared/nCoV2019}
 #'
 #' @keywords internal
 #'

--- a/man/Belgium.Rd
+++ b/man/Belgium.Rd
@@ -4,11 +4,11 @@
 \alias{Belgium}
 \title{Belgium Class for downloading, cleaning and processing notification data}
 \source{
-https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv
+\url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
 
-https://epistat.sciensano.be/Data/COVID19BE_HOSP.csv
+\url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
 
-https://epistat.sciensano.be/Data/COVID19BE_MORT.csv
+\url{https://epistat.sciensano.be/Data/COVID19BE_CASES_AGESEX.csv}
 }
 \description{
 Country specific information for downloading, cleaning
@@ -35,7 +35,10 @@ region$return()
 
 \item{\code{supported_region_names}}{A list of region names in order of level.}
 
-\item{\code{supported_region_codes}}{A list of region codes in order of level.}
+\item{\code{supported_region_codes}}{A list of region codes in order of level.
+ISO 3166-2 codes are used for both region and province levels in
+Belgium, and for provinces these are marked as being
+\code{iso_3166_2_province}}
 
 \item{\code{common_data_urls}}{List of named links to raw data that are common
 across levels.}

--- a/man/Brazil.Rd
+++ b/man/Brazil.Rd
@@ -4,7 +4,7 @@
 \alias{Brazil}
 \title{Brazil Class for downloading, cleaning and processing notification data}
 \source{
-https://github.com/wcota/covid19br
+\url{https://github.com/wcota/covid19br}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Canada.Rd
+++ b/man/Canada.Rd
@@ -4,7 +4,7 @@
 \alias{Canada}
 \title{Canada Class containing country specific attributes and methods}
 \source{
-https://health-infobase.canada.ca
+\url{https://health-infobase.canada.ca}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Colombia.Rd
+++ b/man/Colombia.Rd
@@ -4,7 +4,7 @@
 \alias{Colombia}
 \title{Colombia Class for downloading, cleaning and processing notification data}
 \source{
-https://raw.githubusercontent.com/danielcs88/colombia_covid-19/master/datos/cronologia.csv  # nolint
+\url{https://raw.githubusercontent.com/danielcs88/colombia_covid-19/master/datos/cronologia.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Cuba.Rd
+++ b/man/Cuba.Rd
@@ -4,7 +4,7 @@
 \alias{Cuba}
 \title{Cuba Class for downloading, cleaning and processing notification data}
 \source{
-https://covid19cubadata.github.io/data/covid19-casos.csv  # nolint
+\url{https://covid19cubadata.github.io/data/covid19-casos.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/ECDC.Rd
+++ b/man/ECDC.Rd
@@ -4,7 +4,7 @@
 \alias{ECDC}
 \title{R6 Class containing specific attributes and methods for ECDC dataset}
 \source{
-https://opendata.ecdc.europa.eu/covid19/casedistribution/csv
+\url{https://opendata.ecdc.europa.eu/covid19/casedistribution/csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/France.Rd
+++ b/man/France.Rd
@@ -4,11 +4,11 @@
 \alias{France}
 \title{France Class containing country specific attributes and methods}
 \source{
-https://www.data.gouv.fr/fr/datasets/r/406c6a23-e283-4300-9484-54e78c8ae675
+\url{https://www.data.gouv.fr/fr/datasets/r/406c6a23-e283-4300-9484-54e78c8ae675}
 
-https://www.data.gouv.fr/fr/datasets/r/6fadff46-9efd-4c53-942a-54aca783c30c
+\url{https://www.data.gouv.fr/fr/datasets/r/6fadff46-9efd-4c53-942a-54aca783c30c}
 
-https://www.data.gouv.fr/fr/datasets/r/001aca18-df6a-45c8-89e6-f82d689e6c01
+\url{https://www.data.gouv.fr/fr/datasets/r/001aca18-df6a-45c8-89e6-f82d689e6c01}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Germany.Rd
+++ b/man/Germany.Rd
@@ -4,7 +4,7 @@
 \alias{Germany}
 \title{Germany Class for downloading, cleaning and processing notification data}
 \source{
-https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv  # nolint
+\url{https://opendata.arcgis.com/datasets/dd4580c810204019a7b8eb3e0b329dd6_0.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/India.Rd
+++ b/man/India.Rd
@@ -4,7 +4,7 @@
 \alias{India}
 \title{India Class for downloading, cleaning and processing notification data}
 \source{
-https://api.covid19india.org/csv/latest/state_wise_daily.csv
+\url{https://api.covid19india.org/csv/latest/state_wise_daily.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Italy.Rd
+++ b/man/Italy.Rd
@@ -4,7 +4,7 @@
 \alias{Italy}
 \title{Italy Class for downloading, cleaning and processing notification data}
 \source{
-https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv  # nolint
+\url{https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv  # nolint}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Lithuania.Rd
+++ b/man/Lithuania.Rd
@@ -4,7 +4,7 @@
 \alias{Lithuania}
 \title{Lithuania Class for downloading, cleaning and processing notification data}
 \source{
-https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0
+\url{https://opendata.arcgis.com/datasets/d49a63c934be4f65a93b6273785a8449_0}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/Mexico.Rd
+++ b/man/Mexico.Rd
@@ -4,7 +4,7 @@
 \alias{Mexico}
 \title{Meixco Class for downloading, cleaning and processing notification data}
 \source{
-https://datos.covid-19.conacyt.mx/#DownZCSV
+\url{https://datos.covid-19.conacyt.mx/#DownZCSV}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/SouthAfrica.Rd
+++ b/man/SouthAfrica.Rd
@@ -4,9 +4,9 @@
 \alias{SouthAfrica}
 \title{SouthAfrica Class for downloading, cleaning and processing notification data}
 \source{
-https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv
+\url{https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_confirmed.csv}
 
-https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_deaths.csv
+\url{https://raw.githubusercontent.com/dsfsi/covid19za/master/data/covid19za_provincial_cumulative_timeline_deaths.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/UK.Rd
+++ b/man/UK.Rd
@@ -215,7 +215,7 @@ Set filters for UK data api query.
 Download NHS data for level 1 regions
 Separate NHS data is available for "first" admissions, excluding
 readmissions. This is available for England + English regions only.
-See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+See: \url{https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/}
 Section 2, "2. Estimated new hospital cases"
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{UK$download_nhs_regions()}\if{html}{\out{</div>}}
@@ -232,7 +232,7 @@ nhs data.frame of nhs regions
 Add NHS data for level 1 regions
 Separate NHS data is available for "first" admissions, excluding
 readmissions. This is available for England + English regions only.
-See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
+See: \url{https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/}
 Section 2, "2. Estimated new hospital cases"
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{UK$add_nhs_regions(clean_data, nhs_data)}\if{html}{\out{</div>}}

--- a/man/UK.Rd
+++ b/man/UK.Rd
@@ -5,9 +5,9 @@
 \title{United Kingdom Class for downloading, cleaning and processing notification
 data.}
 \source{
-https://coronavirus.data.gov.uk/details/download #nolint
+\url{https://coronavirus.data.gov.uk/details/download}
 
-https://www.england.nhs.uk/statistics/wp-content/uploads/sites/2/ # nolint
+\url{https://coronavirus.data.gov.uk/details/download}
 }
 \description{
 Extracts daily COVID-19 data for the UK, stratified by region
@@ -215,7 +215,7 @@ Set filters for UK data api query.
 Download NHS data for level 1 regions
 Separate NHS data is available for "first" admissions, excluding
 readmissions. This is available for England + English regions only.
-See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/ # nolint
+See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
 Section 2, "2. Estimated new hospital cases"
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{UK$download_nhs_regions()}\if{html}{\out{</div>}}
@@ -232,7 +232,7 @@ nhs data.frame of nhs regions
 Add NHS data for level 1 regions
 Separate NHS data is available for "first" admissions, excluding
 readmissions. This is available for England + English regions only.
-See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/ # nolint
+See: https://www.england.nhs.uk/statistics/statistical-work-areas/covid-19-hospital-activity/
 Section 2, "2. Estimated new hospital cases"
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{UK$add_nhs_regions(clean_data, nhs_data)}\if{html}{\out{</div>}}

--- a/man/USA.Rd
+++ b/man/USA.Rd
@@ -4,9 +4,9 @@
 \alias{USA}
 \title{USA Class for downloading, cleaning and processing notification data}
 \source{
-https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv # nolint
+\url{https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv}
 
-https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv # nolint
+\url{https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/WHO.Rd
+++ b/man/WHO.Rd
@@ -4,7 +4,7 @@
 \alias{WHO}
 \title{R6 Class containing specific attributes and methods for WHO data}
 \source{
-https://covid19.who.int/WHO-COVID-19-global-data.csv
+\url{https://covid19.who.int/WHO-COVID-19-global-data.csv}
 }
 \description{
 Country specific information for downloading, cleaning

--- a/man/get_interventions_data.Rd
+++ b/man/get_interventions_data.Rd
@@ -4,7 +4,7 @@
 \alias{get_interventions_data}
 \title{Get ACAPS Government Interventions dataset}
 \source{
-https://www.acaps.org/covid-19-government-measures-dataset
+\url{https://www.acaps.org/covid-19-government-measures-dataset}
 }
 \usage{
 get_interventions_data()

--- a/man/get_linelist.Rd
+++ b/man/get_linelist.Rd
@@ -4,7 +4,7 @@
 \alias{get_linelist}
 \title{Get patient linelist data}
 \source{
-https://github.com/beoutbreakprepared/nCoV2019
+\url{https://github.com/beoutbreakprepared/nCoV2019}
 }
 \usage{
 get_linelist(clean = TRUE, report_delay_only = FALSE)


### PR DESCRIPTION
This cleans the `# nolint` problems in the `@source` lines in our documentation, fixing #253 

At the same time it makes every url in the documentation (including outside the `@source` section into live links (which doesn't get done automatically unless the documentation is tagged as markdown, I think).

This also tidies up the naming of region codes in the Belgium data, to match a model in Lithuania regarding this https://github.com/epiforecasts/covidregionaldata/pull/179#discussion_r610919351