### PR TITLE
Extend dataclass tests

### DIFF
--- a/R/shared-methods.R
+++ b/R/shared-methods.R
@@ -259,12 +259,14 @@ DataClass <- R6::R6Class(
           "Filtering data to: ", paste(self$target_regions, collapse = ", ")
         )
         condition <- paste0("level_", self$level, "_region")
-        self$data$clean <- self$data$clean %>%
+        dt <- self$data$clean %>%
           filter(
             eval(parse(text = condition)) %in% self$target_regions
           )
-        if (nrow(self$data$clean) == 0) {
+        if (nrow(dt) == 0) {
           stop("No data found for target regions")
+        } else {
+          self$data$clean <- dt
         }
       }
     },

--- a/tests/testthat/test-CountryDataClass.R
+++ b/tests/testthat/test-CountryDataClass.R
@@ -1,0 +1,18 @@
+test_that("CountryDataClass specific filter method works correctly", {
+  C <- R6::R6Class("C",
+    inherit = CountryDataClass,
+    public = list(
+      common_data_urls = list(
+        main = "custom_data/ecdc.csv"
+      ),
+      clean_common = function() {
+        self$data$clean <- self$data$raw$main
+      }
+    )
+  )
+  c <- C$new(verbose = FALSE)
+  suppressMessages(c$get())
+  expect_error(c$filter("madeupland"))
+  expect_error(c$filter("zambia"), NA)
+  expect_error(c$filter("Zambia"), NA)
+})

--- a/tests/testthat/test-DataClass.R
+++ b/tests/testthat/test-DataClass.R
@@ -47,6 +47,7 @@ test_that("DataClass can clean data", {
 d$clean()
 
 test_that("DataClass can filter data", {
+  expect_error(d$filter("MadeUpLand"))
   expect_error(d$filter("Zambia"), NA)
   expect_s3_class(d$data$clean, "data.frame")
   expect_equal(unique(d$data$clean$level_1_region), "Zambia")
@@ -64,6 +65,12 @@ suppressMessages(d$process())
 test_that("DataClass can return data", {
   expect_error(d$return(), NA)
   expect_s3_class(d$return(), "data.frame")
+  d$steps <- TRUE
+  expect_equal(names(d$return()), c("raw", "clean", "processed", "return"))
+})
+
+test_that("DataClass can use the get method", {
+  expect_error(suppressMessages(d$get()), NA)
   d$steps <- TRUE
   expect_equal(names(d$return()), c("raw", "clean", "processed", "return"))
 })


### PR DESCRIPTION
Adds tests for missing edge cases after looking at the coverage report + adds tests for the CountryDataClass specific methods. 