### PR TITLE
fixed the .x and .y on join bug in India

### DIFF
--- a/R/India.R
+++ b/R/India.R
@@ -67,7 +67,11 @@ India <- R6::R6Class("India",
       cases_deaths_recovered <- data %>%
         reduce(
           full_join,
-          by = c("Date" = "Date", "state" = "state")
+          by = c(
+            "Date" = "Date",
+            "state" = "state",
+            "cases_new" = "cases_new"
+          )
         )
       self$data$clean <- cases_deaths_recovered %>%
         mutate(Date = dmy(Date)) %>%

--- a/R/India.R
+++ b/R/India.R
@@ -69,8 +69,7 @@ India <- R6::R6Class("India",
           full_join,
           by = c(
             "Date" = "Date",
-            "state" = "state",
-            "cases_new" = "cases_new"
+            "state" = "state"
           )
         )
       self$data$clean <- cases_deaths_recovered %>%
@@ -88,10 +87,19 @@ India <- R6::R6Class("India",
     #' @param status The data to extract
     #'
     get_desired_status = function(status) {
+      conversion <- list(
+        "Confirmed" = "cases_new",
+        "Deceased" = "deaths_new",
+        "Recovered"  = "recovered_new"
+      )
       india_cases <- self$data$raw$main %>%
         filter(Status == status) %>%
         select(Date, self$codes_lookup$`1`[["code"]]) %>%
-        pivot_longer(-Date, names_to = "state", values_to = "cases_new")
+        pivot_longer(
+          -Date,
+          names_to = "state",
+          values_to = conversion[[status]]
+        )
     }
   )
 )


### PR DESCRIPTION
<del> Bug seems to be caused by not including "cases_new" on the full join, creating .x and .y versions. </del>

Bug actually caused by `pivot_longer(-Date, names_to = "state", values_to = "cases_new")` which is putting everything in cases_new. Fixed now.