### PR TITLE
changed 'estados' and 'municipios' to 'estado' and 'municipio'

### DIFF
--- a/R/Mexico.R
+++ b/R/Mexico.R
@@ -31,7 +31,7 @@ Mexico <- R6::R6Class("Mexico",
     #' @field supported_levels A list of supported levels.
     supported_levels = list("1", "2"),
     #' @field supported_region_names A list of region names in order of level.
-    supported_region_names = list("1" = "estados", "2" = "municipios"),
+    supported_region_names = list("1" = "estado", "2" = "municipio"),
     #' @field supported_region_codes A list of region codes in order of level.
     supported_region_codes = list("1" = "iso_3166_2", "2" = "inegi"),
     #' @field common_data_urls List of named links to raw data.


### PR DESCRIPTION
made an alteration to change 'estados' and 'municipios' to 'estado' and 'municipio' in `supported_region_names`.