### PR TITLE
Fix for Cuban region code error identified in #119

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ inst/doc
 *.pdf
 /doc/
 /Meta/
-oldversionoutput.rds
-newversionoutput.rds
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ inst/doc
 *.pdf
 /doc/
 /Meta/
+oldversionoutput.rds
+newversionoutput.rds

--- a/R/Cuba.R
+++ b/R/Cuba.R
@@ -44,10 +44,10 @@ Cuba <- R6::R6Class("Cuba",
           "CU-05", "CU-99"
         ),
         region = c(
-          "Artemisa", "Camag\\u00fcey", "Ciego de \\u00c1vila", "Cienfuegos",
-          "Granma", "Guant\\u00e1namo", "Holgu\\u00edn", "La Habana",
-          "Las Tunas", "Matanzas", "Mayabeque", "Pinar del R\\u00edo",
-          "Sancti Sp\\u00edritus", "Santiago de Cuba", "Villa Clara",
+          "Artemisa", "Camag\u00fcey", "Ciego de \u00c1vila", "Cienfuegos",
+          "Granma", "Guant\u00e1namo", "Holgu\u00edn", "La Habana",
+          "Las Tunas", "Matanzas", "Mayabeque", "Pinar del R\u00edo",
+          "Sancti Sp\u00edritus", "Santiago de Cuba", "Villa Clara",
           "Isla de la Juventud"
         )
       )

--- a/R/Cuba.R
+++ b/R/Cuba.R
@@ -40,7 +40,7 @@ Cuba <- R6::R6Class("Cuba",
       self$codes_lookup$`1` <- tibble(
         code = c(
           "CU-15", "CU-09", "CU-08", "CU-06", "CU-12", "CU-14", "CU-11",
-          "CU-03", "CU-10", "CU-04", "CU-16", "CU-01", "CU-07", "C8-13",
+          "CU-03", "CU-10", "CU-04", "CU-16", "CU-01", "CU-07", "CU-13",
           "CU-05", "CU-99"
         ),
         region = c(


### PR DESCRIPTION
There was a typo in an ISO 3166-2 code for one Cuban region. This fixes that.