### PR TITLE
More additional tests on data in regional data

### DIFF
--- a/tests/testthat/custom_tests/test-get_regional_data_checks.R
+++ b/tests/testthat/custom_tests/test-get_regional_data_checks.R
@@ -1,0 +1,36 @@
+test_get_regional_data_region_checks <- function(source, max_level) {
+  data_level_1 <- get_regional_data(source, level = 1, localise = FALSE)
+  if (max_level >= 2) {
+    data_level_2 <- get_regional_data(source, level = 2, localise = FALSE)
+  }
+
+  expect_lte(
+    nrow(
+      unique(
+        data_level_1 %>%
+          select(level_1_region, level_1_region_code) %>%
+          filter(is.na(level_1_region_code))
+        )), 1)
+  if (max_level >= 2) {
+    expect_equal(
+      length(unique(data_level_1$level_1_region)),
+      length(unique(data_level_2$level_1_region)))
+    expect_lte(
+      length(unique(data_level_2$level_1_region)),
+      length(unique(data_level_2$level_2_region)))
+    expect_lte(
+      nrow(
+        unique(
+          data_level_2 %>%
+            select(level_1_region, level_1_region_code) %>%
+            filter(is.na(level_1_region_code)))), 1)
+    if (!is.null(data_level_2$level_2_region_code)) {
+      expect_lte(
+        nrow(
+          unique(
+            data_level_2 %>%
+              select(level_2_region, level_2_region_code) %>%
+              filter(is.na(level_2_region_code)))), 1)
+    }
+  }
+}

--- a/tests/testthat/test-regional-datasets-check.R
+++ b/tests/testthat/test-regional-datasets-check.R
@@ -1,0 +1,48 @@
+# load testing function and tools.
+# set up custom tests using:
+# custom_tests/regional-dataset-specific.R
+#source("custom_tests/test-regional-dataset.R")
+source("custom_tests/test-get_regional_data_checks.R")
+
+# should a single dataset be tested vs all datasets
+# set this when implementing a new dataset.
+# Can also be set using environment variables
+source_of_interest <- NULL
+if (!is.null(getOption("testSource"))) {
+  source_of_interest <- getOption("testSource")
+}
+
+# get datasets for testing
+sources <- get_available_datasets() %>%
+  dplyr::filter(.data$type %in%
+                  c("national", "regional")) %>%
+  dplyr::select(source = class, level_1_region, level_2_region) %>%
+  tidyr::pivot_longer(
+    cols = -source,
+    names_to = "level",
+    values_to = "regions"
+  ) %>%
+  dplyr::mutate(
+    level = stringr::str_split(level, "_"),
+    level = purrr::map_chr(level, ~ .[2])
+  ) %>%
+  tidyr::drop_na(regions)
+
+# filter out target datasets
+if (!is.null(source_of_interest)) {
+  sources <- sources %>%
+    dplyr::filter(source %in% source_of_interest)
+}
+
+# apply tests to each data source in turn
+sources %>%
+  dplyr::group_by(source) %>%
+  dplyr::summarise(level = max(level)) %>%
+  dplyr::rowwise() %>%
+  dplyr::group_split() %>%
+  purrr::walk(
+    ~ test_get_regional_data_region_checks(
+      source = .$source[[1]],
+      max_level = .$level[[1]]
+    )
+  )


### PR DESCRIPTION
Implementation of more tests from #302, intended to be merged into #307 

Checks that the number of regions at level 2 >= the number of regions at level 1
Checks that there is at most 1 level 1 region coded to NA
Checks that there is at most 1 level 2 region coded to NA
Checks that the number of level 1 regions is identical in download of level 1 and level 2 dat

This is a rough implementation.

It currently has a stand-alone wrapper to apply purrr because it only is run once for each country class, but then needs to be told what is the maximum level available from that country class. Notionally, this could allow us to go beyond level 2, but the code doesn't have that recursive flexibility yet. It may be possible to merge the wrapper with the existing file. I've removed the `download` option because these tests only make sense with `download = TRUE`.

The files and possibly the functions probably should be renamed.

It calls `get_regional_data` and I think it doing this since this is the "front end" for most users and there could still be glitches between the data class and the output of `get_regional_data`.

It's not quick.