### PR TITLE
Reorder Lithuania$initialize so params are respected

### DIFF
--- a/R/Lithuania.R
+++ b/R/Lithuania.R
@@ -408,11 +408,11 @@ Lithuania <- R6::R6Class("Lithuania",
                           recovered_definition = "official",
                           all_osp_fields = FALSE,
                           national_data = FALSE, ...) {
-      super$initialize(...)
       self$death_definition <- death_definition
       self$recovered_definition <- recovered_definition
       self$all_osp_fields <- all_osp_fields
       self$national_data <- national_data
+      super$initialize(...)
     }
   )
 )


### PR DESCRIPTION
This is a fix for #341 to re-order the content of the `initialize` method so that optional params are saved into the public fields before calling `super$initialize`.