### PR TITLE
qualify covidregionaldata when loading available datasets

### DIFF
--- a/R/get_available_datasets.R
+++ b/R/get_available_datasets.R
@@ -54,7 +54,7 @@ get_available_datasets <- function(type, render = FALSE,
       bind_rows()
     country_data <- available_country_data
   } else {
-    country_data <- all_country_data
+    country_data <- covidregionaldata::all_country_data
   }
   if (!missing(type)) {
     target_type <- match.arg(


### PR DESCRIPTION
Without this, an error as in #369 still occurs when calling a function without loading the library first.