### PR TITLE
fix Germany case/death data

### DIFF
--- a/R/Germany.R
+++ b/R/Germany.R
@@ -94,8 +94,8 @@ Germany <- R6::R6Class("Germany",
           .data$date
         ) %>%
         summarise(
-          cases_new = as.numeric(sum(.data$cases_new > 0)),
-          deaths_new = as.numeric(sum(.data$deaths_new > 0))
+          cases_new = as.numeric(.data$cases_new)),
+          deaths_new = as.numeric(.data$deaths_new))
         ) %>%
         ungroup()
     },
@@ -116,8 +116,8 @@ Germany <- R6::R6Class("Germany",
           .data$level_2_region, .data$date
         ) %>%
         summarise(
-          cases_new = as.numeric(sum(.data$cases_new > 0)),
-          deaths_new = as.numeric(sum(.data$deaths_new > 0))
+          cases_new = as.numeric(sum(.data$cases_new)),
+          deaths_new = as.numeric(sum(.data$deaths_new))
         ) %>%
         ungroup()
     }

--- a/R/Germany.R
+++ b/R/Germany.R
@@ -94,8 +94,8 @@ Germany <- R6::R6Class("Germany",
           .data$date
         ) %>%
         summarise(
-          cases_new = as.numeric(.data$cases_new)),
-          deaths_new = as.numeric(.data$deaths_new))
+          cases_new = as.numeric(sum(.data$cases_new)),
+          deaths_new = as.numeric(sum(.data$deaths_new))
         ) %>%
         ungroup()
     },


### PR DESCRIPTION
The code as implemented counts every row in the case/death data just once, as if it was a line list of individuals - instead it is relatively finely resolved count data which needs to be summed up.

This is causing problems downstream https://github.com/epiforecasts/covid/issues/184