### PR TITLE
Switch to bootstrap 5 for pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,6 @@
 url: epiforecasts.io/covidregionaldata/
 template:
+  bootstrap: 5
   params:
     bootswatch: lumen
     docsearch:


### PR DESCRIPTION
This PR switches to bootstrap 5 as supported by the latest version of `pkgdown` local inspection shows no issues (and @Bisaloo was also able to render the site without issues). PR linked to #440