### PR TITLE
Fix website URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: epiforecasts.io/covidregionaldata/
+url: https://epiforecasts.io/covidregionaldata/
 template:
   bootstrap: 5
   params:


### PR DESCRIPTION
The url field must contain a valid URL. The current setup is causing some issues with the search feature because the resulting sitemap is incorrect: 

https://github.com/epiforecasts/covidregionaldata/blob/0a910316135fb5768e6afbe7ec8c7297a9bd4d6c/sitemap.xml