### PR TITLE
Call reusable action from all workflows

### DIFF
--- a/.github/workflows/Belgium.yaml
+++ b/.github/workflows/Belgium.yaml
@@ -6,7 +6,7 @@ on:
 name: Belgium
 
 jobs:
-  belgium:
+  Belgium:
     uses: ./.github/workflows/test-regional-datasets.yml
     with: 
       test-source: ${{ github.workflow }}

--- a/.github/workflows/Brazil.yaml
+++ b/.github/workflows/Brazil.yaml
@@ -7,25 +7,6 @@ name: Brazil
 
 jobs:
   Brazil:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Brazil")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Canada.yaml
+++ b/.github/workflows/Canada.yaml
@@ -7,26 +7,6 @@ name: Canada
 
 jobs:
   Canada:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Canada")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Colombia.yaml
+++ b/.github/workflows/Colombia.yaml
@@ -7,25 +7,6 @@ name: Colombia
 
 jobs:
   Colombia:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Colombia")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Covid19DataHub.yaml
+++ b/.github/workflows/Covid19DataHub.yaml
@@ -7,25 +7,6 @@ name: Covid19DataHub
 
 jobs:
   Covid19DataHub:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Covid19DataHub")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Cuba.yaml
+++ b/.github/workflows/Cuba.yaml
@@ -7,25 +7,6 @@ name: Cuba
 
 jobs:
   Cuba:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Cuba")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/ECDC.yaml
+++ b/.github/workflows/ECDC.yaml
@@ -7,25 +7,6 @@ name: ECDC
 
 jobs:
   ECDC:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "ECDC")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Estonia.yaml
+++ b/.github/workflows/Estonia.yaml
@@ -7,25 +7,6 @@ name: Estonia
 
 jobs:
   Estonia:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Estonia")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/France.yaml
+++ b/.github/workflows/France.yaml
@@ -7,25 +7,6 @@ name: France
 
 jobs:
   France:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "France")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Google.yaml
+++ b/.github/workflows/Google.yaml
@@ -7,25 +7,6 @@ name: Google
 
 jobs:
   Google:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Google")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/India.yaml
+++ b/.github/workflows/India.yaml
@@ -7,25 +7,6 @@ name: India
 
 jobs:
   India:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "India")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Italy.yaml
+++ b/.github/workflows/Italy.yaml
@@ -7,25 +7,6 @@ name: Italy
 
 jobs:
   Italy:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Italy")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/JHU.yaml
+++ b/.github/workflows/JHU.yaml
@@ -7,25 +7,6 @@ name: JHU
 
 jobs:
   JHU:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "JHU")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/JRC.yaml
+++ b/.github/workflows/JRC.yaml
@@ -7,25 +7,6 @@ name: JRC
 
 jobs:
   JRC:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "JRC")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Lithuania.yaml
+++ b/.github/workflows/Lithuania.yaml
@@ -7,25 +7,6 @@ name: Lithuania
 
 jobs:
   Lithuania:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Lithuania")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Mexico.yaml
+++ b/.github/workflows/Mexico.yaml
@@ -7,25 +7,6 @@ name: Mexico
 
 jobs:
   Mexico:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Mexico")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Netherlands.yaml
+++ b/.github/workflows/Netherlands.yaml
@@ -7,25 +7,6 @@ name: Netherlands
 
 jobs:
   Netherlands:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Netherlands")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/SouthAfrica.yaml
+++ b/.github/workflows/SouthAfrica.yaml
@@ -7,25 +7,6 @@ name: SouthAfrica
 
 jobs:
   SouthAfrica:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "SouthAfrica")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/Switzerland.yaml
+++ b/.github/workflows/Switzerland.yaml
@@ -7,25 +7,6 @@ name: Switzerland
 
 jobs:
   Switzerland:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: devtools
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "Switzerland")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/UK.yaml
+++ b/.github/workflows/UK.yaml
@@ -7,42 +7,6 @@ name: UK
 
 jobs:
   UK:
-    runs-on: macOS-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("devtools")
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "UK")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/USA.yaml
+++ b/.github/workflows/USA.yaml
@@ -7,42 +7,6 @@ name: USA
 
 jobs:
   USA:
-    runs-on: macOS-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("devtools")
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "USA")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail")) 
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}

--- a/.github/workflows/WHO.yaml
+++ b/.github/workflows/WHO.yaml
@@ -7,42 +7,6 @@ name: WHO
 
 jobs:
   WHO:
-    runs-on: macOS-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("devtools")
-        shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Test dataset
-        run: |
-          options("testDownload" = TRUE)
-          options("testSource" = "WHO")
-          devtools::load_all()
-          testthat::test_file("tests/testthat/test-regional-datasets.R", reporter = c("summary", "fail"))
-        shell: Rscript {0}
+    uses: ./.github/workflows/test-regional-datasets.yml
+    with: 
+      test-source: ${{ github.workflow }}


### PR DESCRIPTION
This allows us to update workflows for all sources by changing a single file (`test-regional-datasets.yml`).

It still feels a little bit strange to have a single file for each data source. A single workflow with a matrix dispatch might be a better approach. But I can't think of getting a badge for each element of the matrix :thinking: 