### PR TITLE
Add oldrel R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,6 +22,7 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:


### PR DESCRIPTION
There is a gap in our coverage where we jump directly from `oldrel-1` to `release`. 

This is also a problem because `oldrel` is defined as a required test to merge PRs. Since this test doesn't exist, PRs never reach the stage where they can be merged (excepted if an admin bypasses the test requirements).